### PR TITLE
feat: brj.Iterable and brj.Iterator protocol types with itr builtins

### DIFF
--- a/language/src/main/kotlin/brj/analyser/Analyser.kt
+++ b/language/src/main/kotlin/brj/analyser/Analyser.kt
@@ -900,6 +900,16 @@ data class Analyser(
                 val first = form.els.firstOrNull() as? SymbolForm
                     ?: return errorType("Type form must start with a symbol", form.loc)
                 when (first.name) {
+                    "Iterable" -> {
+                        val elForm = form.els.getOrNull(1)
+                            ?: return errorType("Iterable type requires an element type", form.loc)
+                        IterableType(analyseTypeForm(elForm, typeVars)).notNull()
+                    }
+                    "Iterator" -> {
+                        val elForm = form.els.getOrNull(1)
+                            ?: return errorType("Iterator type requires an element type", form.loc)
+                        IteratorType(analyseTypeForm(elForm, typeVars)).notNull()
+                    }
                     "Fn" -> {
                         val paramVec = form.els.getOrNull(1) as? VectorForm
                             ?: return errorType("Fn type requires a vector of parameter types", form.loc)

--- a/language/src/main/kotlin/brj/builtins/Builtins.kt
+++ b/language/src/main/kotlin/brj/builtins/Builtins.kt
@@ -45,6 +45,12 @@ object Builtins {
             createBuiltinFunction("not", NotNode(language),
                 FnType(listOf(BoolType.notNull()), BoolType.notNull()).notNull()),
             comparisonOp("same?", SameNode(language)),
+            createBuiltinFunction("itr", ItrNode(language),
+                run { val a = freshType(); FnType(listOf(IterableType(a).notNull()), IteratorType(a).notNull()).notNull() }),
+            createBuiltinFunction("itrHasNext?", ItrHasNextNode(language),
+                run { val a = freshType(); FnType(listOf(IteratorType(a).notNull()), BoolType.notNull()).notNull() }),
+            createBuiltinFunction("itrNext", ItrNextNode(language),
+                run { val a = freshType(); FnType(listOf(IteratorType(a).notNull()), a).notNull() }),
         ).associateBy { it.name }
     }
 

--- a/language/src/main/kotlin/brj/builtins/IteratorNodes.kt
+++ b/language/src/main/kotlin/brj/builtins/IteratorNodes.kt
@@ -1,0 +1,40 @@
+package brj.builtins
+
+import brj.BridjeLanguage
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary
+import com.oracle.truffle.api.frame.VirtualFrame
+import com.oracle.truffle.api.interop.InteropLibrary
+import com.oracle.truffle.api.nodes.RootNode
+
+class ItrNode(language: BridjeLanguage) : RootNode(language) {
+    @Child private var interop: InteropLibrary = InteropLibrary.getFactory().createDispatched(3)
+
+    override fun execute(frame: VirtualFrame): Any {
+        return doGetIterator(frame.arguments[0])
+    }
+
+    @TruffleBoundary
+    private fun doGetIterator(obj: Any): Any = interop.getIterator(obj)
+}
+
+class ItrHasNextNode(language: BridjeLanguage) : RootNode(language) {
+    @Child private var interop: InteropLibrary = InteropLibrary.getFactory().createDispatched(3)
+
+    override fun execute(frame: VirtualFrame): Any {
+        return doHasNext(frame.arguments[0])
+    }
+
+    @TruffleBoundary
+    private fun doHasNext(iter: Any): Any = interop.hasIteratorNextElement(iter)
+}
+
+class ItrNextNode(language: BridjeLanguage) : RootNode(language) {
+    @Child private var interop: InteropLibrary = InteropLibrary.getFactory().createDispatched(3)
+
+    override fun execute(frame: VirtualFrame): Any {
+        return doNext(frame.arguments[0])
+    }
+
+    @TruffleBoundary
+    private fun doNext(iter: Any): Any = interop.getIteratorNextElement(iter)
+}

--- a/language/src/main/kotlin/brj/types/Constraint.kt
+++ b/language/src/main/kotlin/brj/types/Constraint.kt
@@ -37,6 +37,14 @@ internal fun Collection<Constraint>.resolve(): Subst {
                 when {
                     lower.base == upper.base -> { /* ok */ }
 
+                    // Collection types — covariant in element
+                    lower.base is VectorType && upper.base is VectorType -> {
+                        queue.add(lower.base.el subOf upper.base.el)
+                    }
+                    lower.base is SetType && upper.base is SetType -> {
+                        queue.add(lower.base.el subOf upper.base.el)
+                    }
+
                     lower.base is HostType && upper.base is HostType
                         && lower.base.className == upper.base.className
                         && lower.base.args.size == upper.base.args.size

--- a/language/src/main/kotlin/brj/types/Constraint.kt
+++ b/language/src/main/kotlin/brj/types/Constraint.kt
@@ -8,6 +8,12 @@ internal data class Constraint(val lower: Type, val upper: Type)
 
 internal infix fun Type.subOf(upper: Type) = Constraint(this, upper)
 
+// Java interfaces backing the virtual protocol types.
+// See #78: HostType <: IterableType rewrites to HostType <: HostType(j.l.Iterable)
+// and lets existing class hierarchy subtyping handle the rest.
+private val J_L_ITERABLE = Iterable::class.java
+private val J_U_ITERATOR = Iterator::class.java
+
 internal fun Collection<Constraint>.resolve(): Subst {
     val queue: Queue<Constraint> = LinkedList(this)
     var subst: Subst = emptyMap()
@@ -110,6 +116,22 @@ internal fun Collection<Constraint>.resolve(): Subst {
                             }
                         }
                     }
+
+                    // Protocol types with themselves — covariant in el
+                    lower.base is IterableType && upper.base is IterableType ->
+                        queue.add(lower.base.el subOf upper.base.el)
+                    lower.base is IteratorType && upper.base is IteratorType ->
+                        queue.add(lower.base.el subOf upper.base.el)
+
+                    // VectorType <: IterableType — direct, covariant
+                    lower.base is VectorType && upper.base is IterableType ->
+                        queue.add(lower.base.el subOf upper.base.el)
+
+                    // HostType <: protocol type — rewrite to HostType <: HostType(java interface)
+                    lower.base is HostType && upper.base is IterableType ->
+                        queue.add(lower subOf HostType(J_L_ITERABLE.name, listOf(upper.base.el), listOf(Variance.OUT)).notNull())
+                    lower.base is HostType && upper.base is IteratorType ->
+                        queue.add(lower subOf HostType(J_U_ITERATOR.name, listOf(upper.base.el), listOf(Variance.OUT)).notNull())
 
                     lower.base is FnType && upper.base is FnType -> {
                         val lParams = lower.base.paramTypes

--- a/language/src/main/kotlin/brj/types/Subst.kt
+++ b/language/src/main/kotlin/brj/types/Subst.kt
@@ -55,6 +55,11 @@ internal infix fun BaseType.join(other: BaseType): BaseType = when {
     this == other -> this
     this is VectorType && other is VectorType -> VectorType(el.join(other.el))
     this is SetType && other is SetType -> SetType(el.join(other.el))
+    this is IterableType && other is IterableType -> IterableType(el.join(other.el))
+    this is IteratorType && other is IteratorType -> IteratorType(el.join(other.el))
+    // Cross-kind: VectorType ↔ IterableType — join picks the supertype (protocol)
+    this is VectorType && other is IterableType -> other
+    other is VectorType && this is IterableType -> this
     this is HostType && other is HostType && className == other.className && args.size == other.args.size && args.isNotEmpty() ->
         HostType(className, joinArgs(variances, args, other.args), variances)
     // Join of different HostTypes — pick the supertype (less specific)
@@ -86,6 +91,16 @@ internal infix fun BaseType.meet(other: BaseType): BaseType = when {
     this == other -> this
     this is VectorType && other is VectorType -> VectorType(el.meet(other.el))
     this is SetType && other is SetType -> SetType(el.meet(other.el))
+    this is IterableType && other is IterableType -> IterableType(el.meet(other.el))
+    this is IteratorType && other is IteratorType -> IteratorType(el.meet(other.el))
+    // Cross-kind: VectorType ↔ IterableType — meet picks the subtype (VectorType)
+    this is VectorType && other is IterableType -> this
+    other is VectorType && this is IterableType -> other
+    // Cross-kind: HostType ↔ IterableType — meet picks the HostType (subtype)
+    this is HostType && other is IterableType -> this
+    other is HostType && this is IterableType -> other
+    this is HostType && other is IteratorType -> this
+    other is HostType && this is IteratorType -> other
     this is HostType && other is HostType && className == other.className && args.size == other.args.size && args.isNotEmpty() ->
         HostType(className, meetArgs(variances, args, other.args), variances)
     // Meet of different HostTypes — pick the subtype (more specific)
@@ -135,6 +150,8 @@ internal fun BaseType.applySubst(subst: Subst): BaseType = when (this) {
     is TagType -> if (args.isEmpty()) this else TagType(ns, name, args.map { it.applySubst(subst) }, variances)
     is EnumType -> if (args.isEmpty()) this else EnumType(name, args.map { it.applySubst(subst) }, variances)
     is FnType -> FnType(paramTypes.map { it.applySubst(subst) }, returnType.applySubst(subst))
+    is IterableType -> IterableType(el.applySubst(subst))
+    is IteratorType -> IteratorType(el.applySubst(subst))
     else -> this
 }
 

--- a/language/src/main/kotlin/brj/types/Subst.kt
+++ b/language/src/main/kotlin/brj/types/Subst.kt
@@ -53,6 +53,8 @@ private fun meetArgs(variances: List<Variance>, a: List<Type>, b: List<Type>): L
 // Join two base types - must be same or error
 internal infix fun BaseType.join(other: BaseType): BaseType = when {
     this == other -> this
+    this is VectorType && other is VectorType -> VectorType(el.join(other.el))
+    this is SetType && other is SetType -> SetType(el.join(other.el))
     this is HostType && other is HostType && className == other.className && args.size == other.args.size && args.isNotEmpty() ->
         HostType(className, joinArgs(variances, args, other.args), variances)
     // Join of different HostTypes — pick the supertype (less specific)
@@ -82,6 +84,8 @@ internal infix fun BaseType.join(other: BaseType): BaseType = when {
 // Meet two base types - must be same or error
 internal infix fun BaseType.meet(other: BaseType): BaseType = when {
     this == other -> this
+    this is VectorType && other is VectorType -> VectorType(el.meet(other.el))
+    this is SetType && other is SetType -> SetType(el.meet(other.el))
     this is HostType && other is HostType && className == other.className && args.size == other.args.size && args.isNotEmpty() ->
         HostType(className, meetArgs(variances, args, other.args), variances)
     // Meet of different HostTypes — pick the subtype (more specific)
@@ -125,6 +129,8 @@ internal infix fun Type.meet(other: Type): Type {
 }
 
 internal fun BaseType.applySubst(subst: Subst): BaseType = when (this) {
+    is VectorType -> VectorType(el.applySubst(subst))
+    is SetType -> SetType(el.applySubst(subst))
     is HostType -> if (args.isEmpty()) this else HostType(className, args.map { it.applySubst(subst) }, variances)
     is TagType -> if (args.isEmpty()) this else TagType(ns, name, args.map { it.applySubst(subst) }, variances)
     is EnumType -> if (args.isEmpty()) this else EnumType(name, args.map { it.applySubst(subst) }, variances)

--- a/language/src/main/kotlin/brj/types/Type.kt
+++ b/language/src/main/kotlin/brj/types/Type.kt
@@ -141,6 +141,24 @@ data class SetType(val el: Type): BaseType {
     override fun toString() = "#{${el}}"
 }
 
+// Virtual protocol types — no Java class backs these.
+// They represent Truffle iterator protocol capabilities.
+// See #78: Truffle intercepts java.lang.Iterable on TruffleObjects,
+// so BridjeVector can't implement it. These exist in the type system only.
+@ExportLibrary(InteropLibrary::class)
+data class IterableType(val el: Type): BaseType {
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage fun toDisplayString(allowSideEffects: Boolean) = toString()
+    override fun toString() = "Iterable(${el})"
+}
+
+@ExportLibrary(InteropLibrary::class)
+data class IteratorType(val el: Type): BaseType {
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage fun toDisplayString(allowSideEffects: Boolean) = toString()
+    override fun toString() = "Iterator(${el})"
+}
+
 @ExportLibrary(InteropLibrary::class)
 data class FnType(val paramTypes: List<Type>, val returnType: Type): BaseType {
     @Suppress("UNUSED_PARAMETER")
@@ -166,6 +184,8 @@ private val Type.tvs0: List<TypeVar> get() =
         is TagType -> base.args.flatMap { it.tvs0 }
         is EnumType -> base.args.flatMap { it.tvs0 }
         is FnType -> base.paramTypes.flatMap { it.tvs0 } + base.returnType.tvs0
+        is IterableType -> base.el.tvs0
+        is IteratorType -> base.el.tvs0
         else -> emptyList()
     }.plus(tv)
 
@@ -181,6 +201,8 @@ private fun instantiateType(type: Type, mapping: MutableMap<TypeVar, TypeVar>): 
         is TagType -> if (base.args.isEmpty()) base else TagType(base.ns, base.name, base.args.map { instantiateType(it, mapping) }, base.variances)
         is EnumType -> if (base.args.isEmpty()) base else EnumType(base.name, base.args.map { instantiateType(it, mapping) }, base.variances)
         is FnType -> FnType(base.paramTypes.map { instantiateType(it, mapping) }, instantiateType(base.returnType, mapping))
+        is IterableType -> IterableType(instantiateType(base.el, mapping))
+        is IteratorType -> IteratorType(instantiateType(base.el, mapping))
         else -> base
     }
 

--- a/language/src/main/kotlin/brj/types/Type.kt
+++ b/language/src/main/kotlin/brj/types/Type.kt
@@ -116,8 +116,6 @@ data class HostType(val className: String, val args: List<Type> = emptyList(), v
     @Suppress("UNUSED_PARAMETER")
     @ExportMessage fun toDisplayString(allowSideEffects: Boolean) = toString()
     override fun toString(): String = when {
-        className == "brj.runtime.BridjeVector" && args.size == 1 -> "[${args[0]}]"
-        className == "brj.runtime.BridjeSet" && args.size == 1 -> "#{${args[0]}}"
         args.isEmpty() -> className.substringAfterLast('.')
         else -> "${className.substringAfterLast('.')}(${args.joinToString(", ")})"
     }
@@ -130,8 +128,18 @@ data object ErrorType: BaseType {
     override fun toString() = "<error>"
 }
 
-fun VectorType(el: Type) = HostType("brj.runtime.BridjeVector", listOf(el), listOf(Variance.OUT))
-fun SetType(el: Type) = HostType("brj.runtime.BridjeSet", listOf(el), listOf(Variance.OUT))
+@ExportLibrary(InteropLibrary::class)
+data class VectorType(val el: Type): BaseType {
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage fun toDisplayString(allowSideEffects: Boolean) = toString()
+    override fun toString() = "[${el}]"
+}
+@ExportLibrary(InteropLibrary::class)
+data class SetType(val el: Type): BaseType {
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage fun toDisplayString(allowSideEffects: Boolean) = toString()
+    override fun toString() = "#{${el}}"
+}
 
 @ExportLibrary(InteropLibrary::class)
 data class FnType(val paramTypes: List<Type>, val returnType: Type): BaseType {
@@ -152,6 +160,8 @@ fun errorType() = ErrorType.notNull()
 
 private val Type.tvs0: List<TypeVar> get() =
     when (val base = this.base) {
+        is VectorType -> base.el.tvs0
+        is SetType -> base.el.tvs0
         is HostType -> base.args.flatMap { it.tvs0 }
         is TagType -> base.args.flatMap { it.tvs0 }
         is EnumType -> base.args.flatMap { it.tvs0 }
@@ -165,6 +175,8 @@ private fun instantiateType(type: Type, mapping: MutableMap<TypeVar, TypeVar>): 
     fun TypeVar.fresh(): TypeVar = mapping.getOrPut(this) { TypeVar() }
 
     fun instBase(base: BaseType): BaseType = when (base) {
+        is VectorType -> VectorType(instantiateType(base.el, mapping))
+        is SetType -> SetType(instantiateType(base.el, mapping))
         is HostType -> if (base.args.isEmpty()) base else HostType(base.className, base.args.map { instantiateType(it, mapping) }, base.variances)
         is TagType -> if (base.args.isEmpty()) base else TagType(base.ns, base.name, base.args.map { instantiateType(it, mapping) }, base.variances)
         is EnumType -> if (base.args.isEmpty()) base else EnumType(base.name, base.args.map { instantiateType(it, mapping) }, base.variances)

--- a/language/src/test/kotlin/brj/IteratorTest.kt
+++ b/language/src/test/kotlin/brj/IteratorTest.kt
@@ -1,0 +1,107 @@
+package brj
+
+import org.graalvm.polyglot.PolyglotException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class IteratorTest {
+
+    @Test
+    fun `itr on vector returns iterator`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            let: [it itr([1, 2, 3])]
+              itrHasNext?(it)
+        """.trimIndent())
+        assertTrue(result.asBoolean())
+    }
+
+    @Test
+    fun `itrNext returns elements in order`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            def: result
+              let: [it itr([10, 20, 30])]
+                loop: [acc 0]
+                  if: itrHasNext?(it)
+                    recur: add(acc, itrNext(it))
+                    acc
+        """.trimIndent())
+        assertEquals(60L, result.asLong())
+    }
+
+    @Test
+    fun `itr works on Java ArrayList`() = withContext { ctx ->
+        ctx.evalBridje("""
+            ns: test.iter.java
+              import:
+                java.util:
+                  as(ArrayList, AL)
+            decl: AL/new() AL
+            decl: [a] AL/.add(a) Bool
+            def: result
+              let: [xs AL/new()]
+                do:
+                  AL/.add(xs, 10)
+                  AL/.add(xs, 20)
+                  let: [it itr(xs)]
+                    loop: [acc 0]
+                      if: itrHasNext?(it)
+                        recur: add(acc, itrNext(it))
+                        acc
+        """.trimIndent())
+        val result = ctx.evalBridje("test.iter.java/result")
+        assertEquals(30L, result.asLong())
+    }
+
+    @Test
+    fun `vector satisfies Iterable type parameter`() = withContext { ctx ->
+        ctx.evalBridje("""
+            ns: test.iter.type.vec
+            decl: [a] useIterable(Iterable(a)) Int
+            def: useIterable(x) 1
+            def: result useIterable([1, 2, 3])
+        """.trimIndent())
+        val result = ctx.evalBridje("test.iter.type.vec/result")
+        assertEquals(1L, result.asLong())
+    }
+
+    @Test
+    fun `java Iterable satisfies Iterable type parameter`() = withContext { ctx ->
+        ctx.evalBridje("""
+            ns: test.iter.type.jiter
+              import:
+                java.util:
+                  as(ArrayList, AL)
+            decl: AL/new() AL
+            decl: [a] useIterable(Iterable(a)) Int
+            def: useIterable(x) 1
+            def: result useIterable(AL/new())
+        """.trimIndent())
+        val result = ctx.evalBridje("test.iter.type.jiter/result")
+        assertEquals(1L, result.asLong())
+    }
+
+    @Test
+    fun `element type propagates through itr`() = withContext { ctx ->
+        // itr([Int]) should give Iterator(Int), itrNext should return Int
+        // add requires matching types, so this verifies propagation
+        val result = ctx.evalBridje("""
+            def: result
+              let: [it itr([10, 20])]
+                add(itrNext(it), itrNext(it))
+        """.trimIndent())
+        assertEquals(30L, result.asLong())
+    }
+
+    @Test
+    fun `non-iterable type is rejected`() = withContext { ctx ->
+        val ex = assertThrows<PolyglotException> {
+            ctx.evalBridje("""
+                ns: test.iter.type.reject
+                def: result itr(42)
+            """.trimIndent())
+        }
+        assertTrue(ex.message?.contains("not Iterable") == true || ex.message?.contains("Incompatible") == true,
+            "Expected type error for non-iterable, got: ${ex.message}")
+    }
+}

--- a/language/src/test/kotlin/brj/types/ConstraintTest.kt
+++ b/language/src/test/kotlin/brj/types/ConstraintTest.kt
@@ -165,8 +165,8 @@ class ConstraintTest {
             ).resolve()
 
             val result = vecType.applySubst(subst)
-            val vecBase = result.base as HostType
-            assertEquals(IntType, vecBase.args[0].base)
+            val vecBase = result.base as VectorType
+            assertEquals(IntType, vecBase.el.base)
         }
     }
 }

--- a/language/src/test/kotlin/brj/types/SubstTest.kt
+++ b/language/src/test/kotlin/brj/types/SubstTest.kt
@@ -73,8 +73,8 @@ class SubstTest {
 
         @Test
         fun `join VectorTypes joins elements`() {
-            val joined = (VectorType(IntType.notNull()) join VectorType(IntType.notNull())) as HostType
-            assertEquals(IntType, joined.args[0].base)
+            val joined = (VectorType(IntType.notNull()) join VectorType(IntType.notNull())) as VectorType
+            assertEquals(IntType, joined.el.base)
         }
     }
 
@@ -217,8 +217,8 @@ class SubstTest {
             val vecType = VectorType(elemType).notNull()
             val subst = mapOf(elemTv to IntType.notNull())
             val result = vecType.applySubst(subst)
-            val vecBase = result.base as HostType
-            assertEquals(IntType, vecBase.args[0].base)
+            val vecBase = result.base as VectorType
+            assertEquals(IntType, vecBase.el.base)
         }
     }
 }

--- a/language/src/test/kotlin/brj/types/TypeTest.kt
+++ b/language/src/test/kotlin/brj/types/TypeTest.kt
@@ -302,6 +302,45 @@ class TypeTest {
     }
 
     @Test
+    fun `vector subtype of Iterable via constraint solver`() {
+        val tv = TypeVar()
+        val vecType = VectorType(IntType.notNull()).notNull()
+        val iterableType = IterableType(Type(NOT_NULL, tv, null)).notNull()
+        val subst = listOf(vecType subOf iterableType).resolve()
+        val resolved = iterableType.applySubst(subst)
+        assertEquals(IntType, (resolved.base as IterableType).el.base)
+    }
+
+    @Test
+    fun `non-iterable HostType rejected for Iterable`() {
+        val tv = TypeVar()
+        val sbType = HostType("java.lang.StringBuilder").notNull()
+        val iterableType = IterableType(Type(NOT_NULL, tv, null)).notNull()
+        assertThrows(TypeErrorException::class.java) {
+            listOf(sbType subOf iterableType).resolve()
+        }
+    }
+
+    @Test
+    fun `java Iterator subtype of brj Iterator`() {
+        val tv = TypeVar()
+        val hostIter = HostType("java.util.Iterator", listOf(IntType.notNull()), listOf(Variance.OUT)).notNull()
+        val brjIter = IteratorType(Type(NOT_NULL, tv, null)).notNull()
+        val subst = listOf(hostIter subOf brjIter).resolve()
+        val resolved = brjIter.applySubst(subst)
+        assertEquals(IntType, (resolved.base as IteratorType).el.base)
+    }
+
+    @Test
+    fun `IteratorType applySubst resolves element type`() {
+        val tv = TypeVar()
+        val iterType = IteratorType(Type(NOT_NULL, tv, null))
+        val subst = mapOf(tv to IntType.notNull())
+        val resolved = iterType.applySubst(subst)
+        assertEquals(IntType, (resolved as IteratorType).el.base)
+    }
+
+    @Test
     fun `instantiate gives different vars for different originals`() {
         val tv1 = TypeVar()
         val tv2 = TypeVar()

--- a/language/src/test/kotlin/brj/types/TypeTest.kt
+++ b/language/src/test/kotlin/brj/types/TypeTest.kt
@@ -27,8 +27,8 @@ class TypeTest {
         val type = VectorExpr(listOf(IntExpr(1), IntExpr(2))).checkType()
         assertEquals(NOT_NULL, type.nullability)
 
-        val vecBase = type.base as HostType
-        assertEquals(IntType, vecBase.args[0].base)
+        val vecBase = type.base as VectorType
+        assertEquals(IntType, vecBase.el.base)
     }
 
     @Test
@@ -36,9 +36,9 @@ class TypeTest {
         val type = VectorExpr(listOf(IntExpr(1), NilExpr())).checkType()
         assertEquals(NOT_NULL, type.nullability)
 
-        val vecBase = type.base as HostType
-        assertEquals(IntType, vecBase.args[0].base)
-        assertEquals(NULLABLE, vecBase.args[0].nullability)
+        val vecBase = type.base as VectorType
+        assertEquals(IntType, vecBase.el.base)
+        assertEquals(NULLABLE, vecBase.el.nullability)
     }
 
     @Test
@@ -127,9 +127,9 @@ class TypeTest {
             VectorExpr(listOf(NilExpr()))
         ).checkType()
 
-        val vecBase = type.base as HostType
-        assertEquals(IntType, vecBase.args[0].base)
-        assertEquals(NULLABLE, vecBase.args[0].nullability)
+        val vecBase = type.base as VectorType
+        assertEquals(IntType, vecBase.el.base)
+        assertEquals(NULLABLE, vecBase.el.nullability)
     }
 
     @Test
@@ -157,9 +157,8 @@ class TypeTest {
     @Test
     fun `set literal has set type`() {
         val type = SetExpr(listOf(IntExpr(1), IntExpr(2))).checkType()
-        val setBase = type.base as HostType
-        assertEquals("brj.runtime.BridjeSet", setBase.className)
-        assertEquals(IntType, setBase.args[0].base)
+        val setBase = type.base as SetType
+        assertEquals(IntType, setBase.el.base)
         assertEquals(NOT_NULL, type.nullability)
     }
 

--- a/notes/TYPES.md
+++ b/notes/TYPES.md
@@ -157,6 +157,41 @@ Homogeneous, immutable, parameterised by element type:
 Element types are inferred from literals.
 Empty literals (`[]`, `#{}`) infer the element type from usage context.
 
+## Protocol Types
+
+Protocol types represent Truffle interop protocol capabilities rather than Java classes.
+They exist in the Bridje type system only — no Java class backs them.
+
+### Iterable and Iterator
+
+`Iterable(a)` is the type of anything that can produce an iterator over `a`.
+`Iterator(a)` is the type of a stateful cursor yielding values of type `a`.
+
+```bridje
+decl: [a] itr(Iterable(a)) Iterator(a)
+decl: [a] itrHasNext?(Iterator(a)) Bool
+decl: [a] itrNext(Iterator(a)) a
+```
+
+At runtime, `itr` dispatches via Truffle's `InteropLibrary.getIterator()`.
+This works for BridjeVector (via `hasArrayElements` auto-iteration), Java Iterables, and any polyglot object that exports the Truffle iterator protocol.
+
+Subtype relationships:
+
+```
+[a]                    <: Iterable(a)    // BridjeVector
+java.lang.Iterable(a)  <: Iterable(a)
+java.util.Iterator(a)   <: Iterator(a)
+```
+
+These are virtual — BridjeVector does not implement `java.lang.Iterable` at the Java level.
+Truffle intercepts that interface on TruffleObjects, so the relationship is modelled in the constraint solver instead.
+When traits land, the virtual relationships become trait impls.
+
+**Note**: `Iterable` is deliberately separate from a future `brj.List` type.
+Iteration is O(n) sequential access; List implies O(1) indexed access (`count`, `first`, `nth`).
+Conflating them would bake in wrong performance contracts.
+
 ## Function Types
 
 `Fn([a, b] c)` — a function taking `a` and `b`, returning `c`.


### PR DESCRIPTION
## Summary

- Introduces `IterableType` and `IteratorType` as first-class `BaseType` variants in the type system — virtual types backed by Truffle's iterator protocol at runtime
- Adds `itr`, `itrHasNext?`, `itrNext` builtins with proper types: `itr : Iterable(a) -> Iterator(a)`
- Promotes `VectorType` and `SetType` from `HostType` wrappers to their own `BaseType` variants (tidy-first prep)

Resolves #78.

## Context

Bridje needs iterable/iterator support for `map`/`filter`/`reduce` and TaskScope work.
Take 1 (branch `itr-78`) proved the runtime works via `InteropLibrary.getIterator()`, but the type story stalled: Truffle intercepts `java.lang.Iterable` on TruffleObjects, wrapping them as PolyglotList and breaking all interop.

No Java class can back these types, so they live purely in the constraint solver.

## Implementation notes

### Constraint rewriting — the key design choice

Rather than maintaining a registry of "known iterable" class names, the constraint solver *rewrites* `HostType <: IterableType(a)` into `HostType <: HostType(j.l.Iterable, [a])`.
This lets existing class hierarchy subtyping (#87) handle transitivity — ArrayList, LinkedList, etc. all work automatically.

`VectorType` gets a direct constraint arm because BridjeVector isn't a Java subtype of `j.l.Iterable` — that's the whole reason these virtual types exist.

### Why top-level BaseType variants?

`IterableType`/`IteratorType` represent Truffle protocol capabilities, not Java classes — they don't fit as `HostType`s.
`VectorType`/`SetType` were promoted in a prep commit to make the `VectorType <: IterableType` arm natural and clean up element access (`.el` instead of `.args[0]`).

### Why separate from brj.List?

Different O(*) contracts.
`count`/`first`/`nth` are O(1) on List (`hasArrayElements`), O(n) on Iterable.
Conflating them would bake in wrong performance guarantees.
`brj.List` is a future separate concern.

### Forward compatibility

When traits land, the virtual relationships become trait impls and the builtin type signatures stay the same.

## Dead ends

- **BridjeVector implementing `java.lang.Iterable`** — Truffle special-cases this interface on TruffleObjects, wrapping them as PolyglotList. Breaks all 400+ tests. Documented in take 1 chalk.
- **BridjeVector implementing `java.util.List`** — same problem. `List` extends `Iterable`, so Truffle intercepts it identically.
- **Virtual subtype registry with `resolveProtocolEl` helper** — over-engineered for 2-3 entries. The constraint rewriting approach is simpler and delegates transitivity to the existing solver.

## Scope

- **In scope**: IterableType, IteratorType, itr/itrHasNext?/itrNext builtins, VectorType/SetType promotion, type-level + runtime tests, TYPES.md docs
- **Deferred**: `doseq` macro (straightforward on top), `map`/`filter`/`reduce` (#60), `brj.List` type

## Changes

1. `71d400b` — refactor: promote VectorType and SetType to top-level BaseType variants
2. `919c3d0` — feat: brj.Iterable and brj.Iterator protocol types with itr builtins

## Test plan

- [x] 535/535 tests green
- [x] Runtime: itr on vector, loop/recur sum via iterator, itr on Java ArrayList
- [x] Type-level: vector satisfies Iterable param, j.l.Iterable satisfies Iterable param, element type propagation, non-iterable rejection, j.u.Iterator subtyping
- [x] Constraint solver unit tests: VectorType <: IterableType, applySubst on IteratorType

🤖 Generated with [Claude Code](https://claude.com/claude-code)