### PR TITLE
feat: mapv, mapcatv, filterv in brj.core (#60)

### DIFF
--- a/language/src/main/brj/brj/core.brj
+++ b/language/src/main/brj/brj/core.brj
@@ -19,6 +19,27 @@ def: cons(x, xs) Vec/cons(x, xs)
 def: empty?(xs) Vec/isEmpty(xs)
 def: concat(xs, ys) Vec/concat(xs, ys)
 
+decl: [a, b] reduce(Iterable(a), b, Fn([b, a] b)) b
+def: reduce(xs, init, f)
+  let: [it itr(xs)]
+    loop: [acc init]
+      if: itrHasNext?(it)
+        recur: f(acc, itrNext(it))
+        acc
+
+decl: [a, b] mapv(Iterable(a), Fn([a] b)) [b]
+def: mapv(xs, f)
+  reduce(xs, [], fn: step(acc, x) concat(acc, [f(x)]))
+
+decl: [a, b] mapcatv(Iterable(a), Fn([a] [b])) [b]
+def: mapcatv(xs, f)
+  reduce(xs, [], fn: step(acc, x) concat(acc, f(x)))
+
+decl: [a] filterv(Iterable(a), Fn([a] Bool)) [a]
+def: filterv(xs, pred)
+  reduce: xs, []
+    fn: step(acc, x) if: pred(x) concat(acc, [x]) acc
+
 defmacro: cond(& clauses)
   if: empty?(clauses)
     'nil

--- a/language/src/test/kotlin/brj/BuiltinsTest.kt
+++ b/language/src/test/kotlin/brj/BuiltinsTest.kt
@@ -258,6 +258,112 @@ class BuiltinsTest {
         assertEquals(0L, result.arraySize)
     }
 
+    // reduce / mapv / mapcatv / filterv
+
+    @Test
+    fun `reduce folds elements with init`() = withContext { ctx ->
+        val result = ctx.evalBridje("reduce([1, 2, 3, 4], 0, add)")
+        assertEquals(10L, result.asLong())
+    }
+
+    @Test
+    fun `reduce over empty vector returns init`() = withContext { ctx ->
+        val result = ctx.evalBridje("reduce([], 42, add)")
+        assertEquals(42L, result.asLong())
+    }
+
+    @Test
+    fun `reduce can change accumulator type`() = withContext { ctx ->
+        // build a vector by reducing — acc type ([Int]) differs from element type (Int)
+        val result = ctx.evalBridje("reduce([1, 2, 3], [], fn: snoc(acc, x) concat(acc, [x]))")
+        assertTrue(result.hasArrayElements())
+        assertEquals(3L, result.arraySize)
+        assertEquals(1L, result.getArrayElement(0).asLong())
+    }
+
+    @Test
+    fun `mapv applies fn to each element`() = withContext { ctx ->
+        val result = ctx.evalBridje("mapv([1, 2, 3], fn: inc(x) add(x, 1))")
+        assertTrue(result.hasArrayElements())
+        assertEquals(3L, result.arraySize)
+        assertEquals(2L, result.getArrayElement(0).asLong())
+        assertEquals(3L, result.getArrayElement(1).asLong())
+        assertEquals(4L, result.getArrayElement(2).asLong())
+    }
+
+    @Test
+    fun `mapv over empty vector returns empty`() = withContext { ctx ->
+        val result = ctx.evalBridje("mapv([], fn: inc(x) add(x, 1))")
+        assertTrue(result.hasArrayElements())
+        assertEquals(0L, result.arraySize)
+    }
+
+    @Test
+    fun `mapv can change element type`() = withContext { ctx ->
+        val result = ctx.evalBridje("mapv([1, 2], fn: pair(x) [x, x])")
+        assertTrue(result.hasArrayElements())
+        assertEquals(2L, result.arraySize)
+        assertEquals(1L, result.getArrayElement(0).getArrayElement(0).asLong())
+        assertEquals(2L, result.getArrayElement(1).getArrayElement(1).asLong())
+    }
+
+    @Test
+    fun `mapcatv concatenates fn results`() = withContext { ctx ->
+        val result = ctx.evalBridje("mapcatv([1, 2, 3], fn: dup(x) [x, x])")
+        assertTrue(result.hasArrayElements())
+        assertEquals(6L, result.arraySize)
+        assertEquals(1L, result.getArrayElement(0).asLong())
+        assertEquals(1L, result.getArrayElement(1).asLong())
+        assertEquals(2L, result.getArrayElement(2).asLong())
+        assertEquals(2L, result.getArrayElement(3).asLong())
+        assertEquals(3L, result.getArrayElement(4).asLong())
+        assertEquals(3L, result.getArrayElement(5).asLong())
+    }
+
+    @Test
+    fun `mapcatv with empty result vectors`() = withContext { ctx ->
+        val result = ctx.evalBridje("mapcatv([1, 2, 3], fn: none(x) [])")
+        assertTrue(result.hasArrayElements())
+        assertEquals(0L, result.arraySize)
+    }
+
+    @Test
+    fun `mapcatv over empty vector returns empty`() = withContext { ctx ->
+        val result = ctx.evalBridje("mapcatv([], fn: dup(x) [x, x])")
+        assertTrue(result.hasArrayElements())
+        assertEquals(0L, result.arraySize)
+    }
+
+    @Test
+    fun `filterv keeps elements satisfying pred`() = withContext { ctx ->
+        val result = ctx.evalBridje("filterv([1, 2, 3, 4], fn: even(x) eq(0, sub(x, mul(div(x, 2), 2))))")
+        assertTrue(result.hasArrayElements())
+        assertEquals(2L, result.arraySize)
+        assertEquals(2L, result.getArrayElement(0).asLong())
+        assertEquals(4L, result.getArrayElement(1).asLong())
+    }
+
+    @Test
+    fun `filterv with always-true pred preserves all`() = withContext { ctx ->
+        val result = ctx.evalBridje("filterv([1, 2, 3], fn: yes(x) true)")
+        assertTrue(result.hasArrayElements())
+        assertEquals(3L, result.arraySize)
+    }
+
+    @Test
+    fun `filterv with always-false pred returns empty`() = withContext { ctx ->
+        val result = ctx.evalBridje("filterv([1, 2, 3], fn: no(x) false)")
+        assertTrue(result.hasArrayElements())
+        assertEquals(0L, result.arraySize)
+    }
+
+    @Test
+    fun `filterv over empty vector returns empty`() = withContext { ctx ->
+        val result = ctx.evalBridje("filterv([], fn: yes(x) true)")
+        assertTrue(result.hasArrayElements())
+        assertEquals(0L, result.arraySize)
+    }
+
     // Identity comparison
 
     @Test


### PR DESCRIPTION
Part of #60.

A first, deliberately small slice: introduce `reduce`, `mapv`, `mapcatv`, `filterv` so downstream work can start writing real collection transforms instead of hand-rolled `loop`/`recur`.

## Scope

Eager, vector-returning only for `mapv`/`mapcatv`/`filterv` — matches the current object model and sidesteps the lazy-vs-eager question in #60 for now.
Collection-first argument order, consistent with the rest of `brj.core`: `reduce(coll, init, f)`, `mapv(coll, f)`, etc.
Input type is `Iterable(a)`, not `Vec(a)`, so these work across brj vectors, Java collections, and any polyglot iterable.

## Approach

Implemented in pure Bridje on top of the existing `itr` / `itrHasNext?` / `itrNext` builtins plus `loop` / `recur`.
No new Kotlin-side machinery.
`mapv`/`mapcatv`/`filterv` are expressed in terms of `reduce`, so the fold skeleton lives in one place.

The accumulator is built with `concat(acc, [x])`, which is O(n²).
Acceptable for unblocking — we don't have an append-right primitive (`conj`) yet, and the clean fix is to add one rather than contort the pure-Bridje implementation.

## Not in this PR

- `conj` / native builtins — separate performance concern.
- Laziness — still an open question on #60.