### PR TITLE
feat: Loc type and varMeta builtin for var introspection

### DIFF
--- a/language/src/main/kotlin/brj/NsEnv.kt
+++ b/language/src/main/kotlin/brj/NsEnv.kt
@@ -82,8 +82,8 @@ data class NsEnv(
 
     fun effectVar(name: String): GlobalVar? = effectVars[name]
 
-    fun defx(name: String, value: Any?, type: Type): NsEnv =
-        copy(effectVars = effectVars + (name to GlobalVar(name, value, type = type)))
+    fun defx(name: String, value: Any?, type: Type, meta: BridjeRecord = BridjeRecord.EMPTY): NsEnv =
+        copy(effectVars = effectVars + (name to GlobalVar(name, value, meta, type)))
 
     fun decl(name: String, declaredType: Type): NsEnv =
         copy(pendingDecls = pendingDecls + (name to declaredType))

--- a/language/src/main/kotlin/brj/builtins/Builtins.kt
+++ b/language/src/main/kotlin/brj/builtins/Builtins.kt
@@ -40,6 +40,8 @@ object Builtins {
                 FnType(listOf(freshType()), RecordType.notNull()).notNull()),
             createBuiltinFunction("withMeta", WithMetaNode(language),
                 run { val t = freshType(); FnType(listOf(t, RecordType.notNull()), t).notNull() }),
+            createBuiltinFunction("varMeta", VarMetaNode(language),
+                FnType(listOf(FormType.notNull()), RecordType.notNull()).notNull()),
             createBuiltinFunction("throw", ThrowNode(language),
                 FnType(listOf(freshType()), nothingType()).notNull()),
             createBuiltinFunction("not", NotNode(language),

--- a/language/src/main/kotlin/brj/builtins/VarMetaNode.kt
+++ b/language/src/main/kotlin/brj/builtins/VarMetaNode.kt
@@ -1,0 +1,27 @@
+package brj.builtins
+
+import brj.BridjeLanguage
+import brj.QualifiedSymbolForm
+import brj.runtime.Anomaly.Companion.incorrect
+import brj.runtime.BridjeContext
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary
+import com.oracle.truffle.api.frame.VirtualFrame
+import com.oracle.truffle.api.nodes.RootNode
+
+class VarMetaNode(language: BridjeLanguage) : RootNode(language) {
+    override fun execute(frame: VirtualFrame): Any = doVarMeta(frame.arguments[0])
+
+    @TruffleBoundary
+    private fun doVarMeta(arg: Any?): Any {
+        val qsym = arg as? QualifiedSymbolForm
+            ?: throw incorrect("varMeta: expected a qualified symbol, got ${arg?.let { it::class.simpleName }}", this)
+
+        val ctx = BridjeContext.get(this)
+        val nsEnv = ctx.namespaces[qsym.namespace]
+            ?: throw incorrect("varMeta: namespace not found: ${qsym.namespace}", this)
+        val gv = nsEnv[qsym.member] ?: nsEnv.effectVar(qsym.member)
+            ?: throw incorrect("varMeta: var not found: ${qsym.namespace}/${qsym.member}", this)
+
+        return gv.meta
+    }
+}

--- a/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
+++ b/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
@@ -129,6 +129,9 @@ class ParseRootNode(
         return BridjeFunction(outerRoot.callTarget)
     }
 
+    private fun locMeta(expr: Expr): BridjeRecord =
+        expr.loc?.let { BridjeRecord.EMPTY.put("loc", Loc(it)) } ?: BridjeRecord.EMPTY
+
     private fun evalDefTag(expr: DefTagExpr, nsEnv: NsEnv, enumName: String? = null): Pair<Any, NsEnv> {
         val value: Any =
             if (expr.fieldNames.isEmpty()) {
@@ -166,7 +169,7 @@ class ParseRootNode(
             FnType(fieldTypes, returnType.notNull()).notNull()
         }
 
-        return value to nsEnv.def(expr.name, value, type = type)
+        return value to nsEnv.def(expr.name, value, meta = locMeta(expr), type = type)
     }
 
     @TruffleBoundary
@@ -187,7 +190,8 @@ class ParseRootNode(
                 is DefExpr -> {
                     val type = expr.valueExpr.checkType()
                     val effects = expr.valueExpr.inferEffects().toList()
-                    val meta = expr.metaExpr?.let { evalExpr(it, analyser.slotCount) as? BridjeRecord } ?: BridjeRecord.EMPTY
+                    val userMeta = expr.metaExpr?.let { evalExpr(it, analyser.slotCount) as? BridjeRecord } ?: BridjeRecord.EMPTY
+                    val meta = expr.loc?.let { userMeta.put("loc", Loc(it)) } ?: userMeta
 
                     if (effects.isNotEmpty()) {
                         if (expr.valueExpr !is FnExpr) {
@@ -237,7 +241,7 @@ class ParseRootNode(
                     val fn = evalExpr(expr.fn, analyser.slotCount)
                     val fixedArity = if (expr.fn.isVariadic) expr.fn.params.size - 1 else expr.fn.params.size
                     val macro = BridjeMacro(fn!!, fixedArity, expr.fn.isVariadic)
-                    nsEnv = nsEnv.def(expr.name, macro, type = type)
+                    nsEnv = nsEnv.def(expr.name, macro, meta = locMeta(expr), type = type)
                     macro
                 }
 
@@ -283,7 +287,7 @@ class ParseRootNode(
 
                 is DefxExpr -> {
                     val defaultValue = expr.defaultExpr?.let { evalExpr(it, analyser.slotCount) }
-                    nsEnv = nsEnv.defx(expr.name, defaultValue, expr.declaredType)
+                    nsEnv = nsEnv.defx(expr.name, defaultValue, expr.declaredType, meta = locMeta(expr))
                     defaultValue
                 }
 

--- a/language/src/main/kotlin/brj/runtime/Loc.kt
+++ b/language/src/main/kotlin/brj/runtime/Loc.kt
@@ -1,0 +1,68 @@
+package brj.runtime
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary
+import com.oracle.truffle.api.interop.InteropLibrary
+import com.oracle.truffle.api.interop.TruffleObject
+import com.oracle.truffle.api.interop.UnknownIdentifierException
+import com.oracle.truffle.api.library.ExportLibrary
+import com.oracle.truffle.api.library.ExportMessage
+import com.oracle.truffle.api.source.SourceSection
+import com.oracle.truffle.api.strings.TruffleString
+
+@ExportLibrary(InteropLibrary::class)
+object LocMeta : TruffleObject {
+    private val name = TruffleString.fromConstant("Loc", TruffleString.Encoding.UTF_8)
+
+    @ExportMessage fun isMetaObject() = true
+
+    @ExportMessage fun getMetaSimpleName(): Any = name
+
+    @ExportMessage fun getMetaQualifiedName(): Any = name
+
+    @ExportMessage fun isMetaInstance(instance: Any?) = instance is Loc
+
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage fun toDisplayString(allowSideEffects: Boolean) = "Loc"
+}
+
+@ExportLibrary(InteropLibrary::class)
+class Loc(val section: SourceSection) : TruffleObject {
+
+    private val sourceName: TruffleString =
+        TruffleString.fromConstant(section.source.name ?: "<unknown>", TruffleString.Encoding.UTF_8)
+
+    @ExportMessage fun hasMetaObject() = true
+    @ExportMessage fun getMetaObject(): Any = LocMeta
+
+    @ExportMessage fun hasMembers() = true
+
+    @ExportMessage
+    fun getMembers(@Suppress("UNUSED_PARAMETER") includeInternal: Boolean): Any =
+        BridjeRecord.Keys(MEMBERS)
+
+    @ExportMessage
+    fun isMemberReadable(member: String): Boolean = member in MEMBERS
+
+    @ExportMessage
+    @TruffleBoundary
+    @Throws(UnknownIdentifierException::class)
+    fun readMember(member: String): Any = when (member) {
+        "source" -> sourceName
+        "startLine" -> section.startLine.toLong()
+        "startColumn" -> section.startColumn.toLong()
+        "endLine" -> section.endLine.toLong()
+        "endColumn" -> section.endColumn.toLong()
+        else -> throw UnknownIdentifierException.create(member)
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage
+    @TruffleBoundary
+    fun toDisplayString(allowSideEffects: Boolean): String =
+        "Loc(${section.source.name ?: "<unknown>"}:${section.startLine}:${section.startColumn})"
+
+    companion object {
+        private val MEMBERS: Array<Any> =
+            arrayOf("source", "startLine", "startColumn", "endLine", "endColumn")
+    }
+}

--- a/language/src/test/kotlin/brj/VarMetaTest.kt
+++ b/language/src/test/kotlin/brj/VarMetaTest.kt
@@ -1,0 +1,52 @@
+package brj
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class VarMetaTest {
+
+    @Test
+    fun `varMeta returns empty record for a builtin without user meta or loc`() = withContext { ctx ->
+        // brj.core/add is a builtin — no source location recorded at register time.
+        val meta = ctx.evalBridje("varMeta(`add)")
+        assertTrue(meta.hasMembers())
+        assertFalse(meta.hasMember("loc"))
+    }
+
+    @Test
+    fun `varMeta returns loc for a user-defined def`() = withContext { ctx ->
+        ctx.evalBridje("""
+            ns: test.loc
+            def: foo(x) x
+        """.trimIndent())
+
+        val meta = ctx.evalBridje("varMeta(`test.loc/foo)")
+        assertTrue(meta.hasMembers(), "meta should have members")
+        assertTrue(meta.hasMember("loc"), "meta should carry :loc")
+
+        val loc = meta.getMember("loc")
+        assertEquals("Loc", loc.metaObject.metaSimpleName)
+        assertTrue(loc.hasMember("source"))
+        assertTrue(loc.hasMember("startLine"))
+        assertTrue(loc.hasMember("startColumn"))
+        assertTrue(loc.hasMember("endLine"))
+        assertTrue(loc.hasMember("endColumn"))
+
+        val startLine = loc.getMember("startLine").asLong()
+        assertTrue(startLine > 0, "startLine must be positive")
+    }
+
+    @Test
+    fun `varMeta preserves user meta alongside loc`() = withContext { ctx ->
+        ctx.evalBridje("""
+            ns: test.loc.user
+            ^:test
+            def: myTest nil
+        """.trimIndent())
+
+        val meta = ctx.evalBridje("varMeta(`test.loc.user/myTest)")
+        assertTrue(meta.hasMember("test"), "user meta :test must be preserved")
+        assertTrue(meta.hasMember("loc"), ":loc must be added")
+        assertTrue(meta.getMember("test").asBoolean())
+    }
+}


### PR DESCRIPTION
Part of #20.

An LSP for Bridje needs go-to-def and hover — both boil down to "given a symbol, where was it defined and what do we know about it?".
The naive path is to rebuild symbol resolution inside the LSP server, but Truffle already exposes `namespaces → NsEnv → vars` via the language scope interop.
The LSP can read everything about a loaded program through that surface — except source locations, which nothing was writing.

This PR adds the two missing pieces: a first-class `Loc` value, and a Bridje-side `varMeta` builtin that reads it back.

## `Loc`

Wraps a `SourceSection` as a Truffle object with record-shaped members (`:source`, `:startLine`, `:startColumn`, `:endLine`, `:endColumn`).
Separate `LocMeta` singleton for the Truffle meta-object protocol — same pattern as `SymbolMeta`/`IntMeta` rather than `BridjeTagConstructor`, since `Loc` is emitted only by the analyser and never constructed from user code.

## Loc on var meta at def time

At `def` / `defmacro` / `defx` / `def-tag` (incl. enum variants), a `Loc(expr.loc)` is added to the var's `BridjeRecord` meta under `:loc`, merged with any user-supplied meta so `^:test` and friends survive.
`NsEnv.defx` gained a `meta` parameter so effect vars line up with the rest.

## `brj.core/varMeta`

Takes a `QualifiedSymbolForm`, returns the var's meta record.
Paired with the backtick syntax-quote, ``varMeta(`foo)`` resolves `foo` against the current ns and returns its meta — the user-facing read side of what the LSP sees through interop.

## Scope

`defKey` and `defInterop` deliberately don't get `:loc` yet — niche LSP targets with no meaningful user-visible source position.
The LSP server itself isn't touched in this PR — language-side foundation only.

## Test plan

- [x] `:language:test` — all 561 tests pass, 3 new in `VarMetaTest`
- [x] User meta (`^:test`) is preserved alongside `:loc`
- [x] `varMeta` resolves vars in both user namespaces and `brj.core`