### PR TITLE
feat: first-class Symbol type as name currency

### DIFF
--- a/language/src/main/kotlin/brj/Form.kt
+++ b/language/src/main/kotlin/brj/Form.kt
@@ -2,6 +2,8 @@ package brj
 
 import brj.runtime.BridjeVector
 import brj.runtime.BuiltinMetaObj
+import brj.runtime.Symbol
+import brj.runtime.sym
 import com.oracle.truffle.api.interop.ArityException
 import com.oracle.truffle.api.interop.InteropLibrary
 import com.oracle.truffle.api.interop.InvalidArrayIndexException
@@ -14,30 +16,30 @@ import java.math.BigDecimal
 import java.math.BigInteger
 
 // Meta objects for each form type
-object SymbolMeta : BuiltinMetaObj("Symbol", "brj.forms") {
+object SymbolFormMeta : BuiltinMetaObj("SymbolForm".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is SymbolForm
 
     @Throws(ArityException::class)
     override fun execute(arguments: Array<Any?>): Any {
         if (arguments.size != 1) throw ArityException.create(1, 1, arguments.size)
-        val str = arguments[0] as TruffleString
-        return SymbolForm(str.toJavaStringUncached())
+        val sym = arguments[0] as Symbol
+        return SymbolForm(sym)
     }
 }
 
-object QSymbolMeta : BuiltinMetaObj("QSymbol", "brj.forms") {
+object QSymbolFormMeta : BuiltinMetaObj("QSymbolForm".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is QSymbolForm
 
     @Throws(ArityException::class)
     override fun execute(arguments: Array<Any?>): Any {
         if (arguments.size != 2) throw ArityException.create(2, 2, arguments.size)
-        val ns = (arguments[0] as TruffleString).toJavaStringUncached()
-        val member = (arguments[1] as TruffleString).toJavaStringUncached()
+        val ns = arguments[0] as Symbol
+        val member = arguments[1] as Symbol
         return QSymbolForm(ns, member)
     }
 }
 
-object ListMeta : BuiltinMetaObj("List", "brj.forms") {
+object ListMeta : BuiltinMetaObj("List".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is ListForm
 
     @Throws(ArityException::class)
@@ -48,7 +50,7 @@ object ListMeta : BuiltinMetaObj("List", "brj.forms") {
     }
 }
 
-object VectorMeta : BuiltinMetaObj("Vector", "brj.forms") {
+object VectorMeta : BuiltinMetaObj("Vector".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is VectorForm
 
     @Throws(ArityException::class)
@@ -59,7 +61,7 @@ object VectorMeta : BuiltinMetaObj("Vector", "brj.forms") {
     }
 }
 
-object RecordMeta : BuiltinMetaObj("Record", "brj.forms") {
+object RecordMeta : BuiltinMetaObj("Record".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is RecordForm
 
     @Throws(ArityException::class)
@@ -70,7 +72,7 @@ object RecordMeta : BuiltinMetaObj("Record", "brj.forms") {
     }
 }
 
-object SetMeta : BuiltinMetaObj("Set", "brj.forms") {
+object SetMeta : BuiltinMetaObj("Set".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is SetForm
 
     @Throws(ArityException::class)
@@ -81,7 +83,7 @@ object SetMeta : BuiltinMetaObj("Set", "brj.forms") {
     }
 }
 
-object IntMeta : BuiltinMetaObj("Int", "brj.forms") {
+object IntMeta : BuiltinMetaObj("Int".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is IntForm
 
     @Throws(ArityException::class)
@@ -91,7 +93,7 @@ object IntMeta : BuiltinMetaObj("Int", "brj.forms") {
     }
 }
 
-object DoubleMeta : BuiltinMetaObj("Double", "brj.forms") {
+object DoubleMeta : BuiltinMetaObj("Double".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is DoubleForm
 
     @Throws(ArityException::class)
@@ -101,7 +103,7 @@ object DoubleMeta : BuiltinMetaObj("Double", "brj.forms") {
     }
 }
 
-object StringMeta : BuiltinMetaObj("String", "brj.forms") {
+object StringMeta : BuiltinMetaObj("String".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is StringForm
 
     @Throws(ArityException::class)
@@ -112,7 +114,7 @@ object StringMeta : BuiltinMetaObj("String", "brj.forms") {
     }
 }
 
-object BigIntMeta : BuiltinMetaObj("BigInt", "brj.forms") {
+object BigIntMeta : BuiltinMetaObj("BigInt".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is BigIntForm
 
     @Throws(ArityException::class)
@@ -122,7 +124,7 @@ object BigIntMeta : BuiltinMetaObj("BigInt", "brj.forms") {
     }
 }
 
-object BigDecMeta : BuiltinMetaObj("BigDec", "brj.forms") {
+object BigDecMeta : BuiltinMetaObj("BigDec".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is BigDecForm
 
     @Throws(ArityException::class)
@@ -132,53 +134,53 @@ object BigDecMeta : BuiltinMetaObj("BigDec", "brj.forms") {
     }
 }
 
-object KeywordMeta : BuiltinMetaObj("Keyword", "brj.forms") {
+object KeywordFormMeta : BuiltinMetaObj("KeywordForm".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is KeywordForm
 
     @Throws(ArityException::class)
     override fun execute(arguments: Array<Any?>): Any {
         if (arguments.size != 1) throw ArityException.create(1, 1, arguments.size)
-        val str = arguments[0] as TruffleString
-        return KeywordForm(str.toJavaStringUncached())
+        val sym = arguments[0] as Symbol
+        return KeywordForm(sym)
     }
 }
 
-object QKeywordMeta : BuiltinMetaObj("QKeyword", "brj.forms") {
+object QKeywordFormMeta : BuiltinMetaObj("QKeywordForm".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is QKeywordForm
 
     @Throws(ArityException::class)
     override fun execute(arguments: Array<Any?>): Any {
         if (arguments.size != 2) throw ArityException.create(2, 2, arguments.size)
-        val ns = (arguments[0] as TruffleString).toJavaStringUncached()
-        val member = (arguments[1] as TruffleString).toJavaStringUncached()
+        val ns = arguments[0] as Symbol
+        val member = arguments[1] as Symbol
         return QKeywordForm(ns, member)
     }
 }
 
-object DotSymbolMeta : BuiltinMetaObj("DotSymbol", "brj.forms") {
+object DotSymbolFormMeta : BuiltinMetaObj("DotSymbolForm".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is DotSymbolForm
 
     @Throws(ArityException::class)
     override fun execute(arguments: Array<Any?>): Any {
         if (arguments.size != 1) throw ArityException.create(1, 1, arguments.size)
-        val str = arguments[0] as TruffleString
-        return DotSymbolForm(str.toJavaStringUncached())
+        val sym = arguments[0] as Symbol
+        return DotSymbolForm(sym)
     }
 }
 
-object QDotSymbolMeta : BuiltinMetaObj("QDotSymbol", "brj.forms") {
+object QDotSymbolFormMeta : BuiltinMetaObj("QDotSymbolForm".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is QDotSymbolForm
 
     @Throws(ArityException::class)
     override fun execute(arguments: Array<Any?>): Any {
         if (arguments.size != 2) throw ArityException.create(2, 2, arguments.size)
-        val ns = (arguments[0] as TruffleString).toJavaStringUncached()
-        val member = (arguments[1] as TruffleString).toJavaStringUncached()
+        val ns = arguments[0] as Symbol
+        val member = arguments[1] as Symbol
         return QDotSymbolForm(ns, member)
     }
 }
 
-object UnquoteMeta : BuiltinMetaObj("Unquote", "brj.forms") {
+object UnquoteMeta : BuiltinMetaObj("Unquote".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is UnquoteForm
 
     @Throws(ArityException::class)
@@ -188,7 +190,7 @@ object UnquoteMeta : BuiltinMetaObj("Unquote", "brj.forms") {
     }
 }
 
-object UnquoteSpliceMeta : BuiltinMetaObj("UnquoteSplice", "brj.forms") {
+object UnquoteSpliceMeta : BuiltinMetaObj("UnquoteSplice".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is UnquoteSpliceForm
 
     @Throws(ArityException::class)
@@ -198,7 +200,7 @@ object UnquoteSpliceMeta : BuiltinMetaObj("UnquoteSplice", "brj.forms") {
     }
 }
 
-object SyntaxQuoteMeta : BuiltinMetaObj("SyntaxQuote", "brj.forms") {
+object SyntaxQuoteMeta : BuiltinMetaObj("SyntaxQuote".sym, "brj.forms".sym) {
     override fun isMetaInstance(instance: Any?) = instance is SyntaxQuoteForm
 
     @Throws(ArityException::class)
@@ -219,10 +221,10 @@ sealed class Form : TruffleObject {
     abstract fun copy(): Form
 
     fun withMeta(keyword: KeywordForm): Form =
-        withMeta(RecordForm(listOf(keyword, SymbolForm("true")), keyword.loc))
+        withMeta(RecordForm(listOf(keyword, SymbolForm("true".sym)), keyword.loc))
 
     fun withMeta(keyword: QKeywordForm): Form =
-        withMeta(RecordForm(listOf(keyword, SymbolForm("true")), keyword.loc))
+        withMeta(RecordForm(listOf(keyword, SymbolForm("true".sym)), keyword.loc))
 
     fun withMeta(record: RecordForm): Form = copy().also {
         it.meta = if (meta == null) record else RecordForm(meta!!.els + record.els, record.loc)
@@ -273,40 +275,40 @@ class StringForm(val value: String, override val loc: SourceSection? = null) : F
     override fun toString(): String = "\"${value.reescape()}\""
 }
 
-class SymbolForm(val name: String, override val loc: SourceSection? = null) : Form() {
-    override val metaObj = SymbolMeta
-    override fun copy() = SymbolForm(name, loc)
-    override fun toString(): String = name
+class SymbolForm(val sym: Symbol, override val loc: SourceSection? = null) : Form() {
+    override val metaObj = SymbolFormMeta
+    override fun copy() = SymbolForm(sym, loc)
+    override fun toString(): String = sym.name
 }
 
-class QSymbolForm(val namespace: String, val member: String, override val loc: SourceSection? = null) : Form() {
-    override val metaObj = QSymbolMeta
-    override fun copy() = QSymbolForm(namespace, member, loc)
-    override fun toString(): String = "$namespace/$member"
+class QSymbolForm(val ns: Symbol, val member: Symbol, override val loc: SourceSection? = null) : Form() {
+    override val metaObj = QSymbolFormMeta
+    override fun copy() = QSymbolForm(ns, member, loc)
+    override fun toString(): String = "${ns.name}/${member.name}"
 }
 
-class KeywordForm(val name: String, override val loc: SourceSection? = null) : Form() {
-    override val metaObj = KeywordMeta
-    override fun copy() = KeywordForm(name, loc)
-    override fun toString(): String = ":$name"
+class KeywordForm(val sym: Symbol, override val loc: SourceSection? = null) : Form() {
+    override val metaObj = KeywordFormMeta
+    override fun copy() = KeywordForm(sym, loc)
+    override fun toString(): String = ":${sym.name}"
 }
 
-class QKeywordForm(val namespace: String, val member: String, override val loc: SourceSection? = null) : Form() {
-    override val metaObj = QKeywordMeta
-    override fun copy() = QKeywordForm(namespace, member, loc)
-    override fun toString(): String = ":$namespace/$member"
+class QKeywordForm(val ns: Symbol, val member: Symbol, override val loc: SourceSection? = null) : Form() {
+    override val metaObj = QKeywordFormMeta
+    override fun copy() = QKeywordForm(ns, member, loc)
+    override fun toString(): String = ":${ns.name}/${member.name}"
 }
 
-class DotSymbolForm(val name: String, override val loc: SourceSection? = null) : Form() {
-    override val metaObj = DotSymbolMeta
-    override fun copy() = DotSymbolForm(name, loc)
-    override fun toString(): String = ".$name"
+class DotSymbolForm(val sym: Symbol, override val loc: SourceSection? = null) : Form() {
+    override val metaObj = DotSymbolFormMeta
+    override fun copy() = DotSymbolForm(sym, loc)
+    override fun toString(): String = ".${sym.name}"
 }
 
-class QDotSymbolForm(val namespace: String, val member: String, override val loc: SourceSection? = null) : Form() {
-    override val metaObj = QDotSymbolMeta
-    override fun copy() = QDotSymbolForm(namespace, member, loc)
-    override fun toString(): String = "$namespace/.$member"
+class QDotSymbolForm(val ns: Symbol, val member: Symbol, override val loc: SourceSection? = null) : Form() {
+    override val metaObj = QDotSymbolFormMeta
+    override fun copy() = QDotSymbolForm(ns, member, loc)
+    override fun toString(): String = "${ns.name}/.${member.name}"
 }
 
 @ExportLibrary(InteropLibrary::class)

--- a/language/src/main/kotlin/brj/GlobalVar.kt
+++ b/language/src/main/kotlin/brj/GlobalVar.kt
@@ -1,9 +1,10 @@
 package brj
 
 import brj.runtime.BridjeRecord
+import brj.runtime.Symbol
 import brj.types.Type
 import com.oracle.truffle.api.interop.TruffleObject
 
-class GlobalVar(val name: String, val value: Any?, val meta: BridjeRecord = BridjeRecord.EMPTY, val type: Type? = null, val effects: List<GlobalVar> = emptyList()) : TruffleObject {
-    override fun toString(): String = "#'$name"
+class GlobalVar(val name: Symbol, val value: Any?, val meta: BridjeRecord = BridjeRecord.EMPTY, val type: Type? = null, val effects: List<GlobalVar> = emptyList()) : TruffleObject {
+    override fun toString(): String = "#'${name.name}"
 }

--- a/language/src/main/kotlin/brj/NsEnv.kt
+++ b/language/src/main/kotlin/brj/NsEnv.kt
@@ -17,6 +17,9 @@ import brj.runtime.Anomaly
 import brj.runtime.BridjeFunction
 import brj.runtime.BridjeRecord
 import brj.runtime.FileMeta
+import brj.runtime.Symbol
+import brj.runtime.SymbolMeta
+import brj.runtime.sym
 import brj.types.BoolType
 import brj.types.FnType
 import brj.types.RecordType
@@ -42,38 +45,39 @@ typealias Imports = Map<String, String>
 data class NsEnv(
     val requires: Requires = emptyMap(),
     val imports: Imports = emptyMap(),
-    val vars: Map<String, GlobalVar> = emptyMap(),
-    val keys: Map<String, GlobalVar> = emptyMap(),
-    val effectVars: Map<String, GlobalVar> = emptyMap(),
+    val vars: Map<Symbol, GlobalVar> = emptyMap(),
+    val keys: Map<Symbol, GlobalVar> = emptyMap(),
+    val effectVars: Map<Symbol, GlobalVar> = emptyMap(),
     val interopVars: Map<String, GlobalVar> = emptyMap(),
-    val pendingDecls: Map<String, Type> = emptyMap(),
-    val enums: Map<String, Set<String>> = emptyMap(),
+    val pendingDecls: Map<Symbol, Type> = emptyMap(),
+    val enums: Map<Symbol, Set<Symbol>> = emptyMap(),
     val nsDecl: NsDecl? = null,
     val source: Source? = null,
 ) : TruffleObject {
     companion object {
         private val builtinFormMetas = mapOf(
-            "Symbol" to GlobalVar("Symbol", SymbolMeta),
-            "QSymbol" to GlobalVar("QSymbol", QSymbolMeta),
-            "List" to GlobalVar("List", ListMeta),
-            "Vector" to GlobalVar("Vector", VectorMeta),
-            "Record" to GlobalVar("Record", RecordMeta),
-            "Set" to GlobalVar("Set", SetMeta),
-            "Int" to GlobalVar("Int", IntMeta),
-            "Double" to GlobalVar("Double", DoubleMeta),
-            "String" to GlobalVar("String", StringMeta),
-            "BigInt" to GlobalVar("BigInt", BigIntMeta),
-            "BigDec" to GlobalVar("BigDec", BigDecMeta),
-            "Keyword" to GlobalVar("Keyword", KeywordMeta),
-            "QKeyword" to GlobalVar("QKeyword", QKeywordMeta),
-            "DotSymbol" to GlobalVar("DotSymbol", DotSymbolMeta),
-            "QDotSymbol" to GlobalVar("QDotSymbol", QDotSymbolMeta),
+            "Symbol".sym to GlobalVar("Symbol".sym, SymbolMeta),
+            "SymbolForm".sym to GlobalVar("SymbolForm".sym, SymbolFormMeta),
+            "QSymbolForm".sym to GlobalVar("QSymbolForm".sym, QSymbolFormMeta),
+            "KeywordForm".sym to GlobalVar("KeywordForm".sym, KeywordFormMeta),
+            "QKeywordForm".sym to GlobalVar("QKeywordForm".sym, QKeywordFormMeta),
+            "DotSymbolForm".sym to GlobalVar("DotSymbolForm".sym, DotSymbolFormMeta),
+            "QDotSymbolForm".sym to GlobalVar("QDotSymbolForm".sym, QDotSymbolFormMeta),
+            "List".sym to GlobalVar("List".sym, ListMeta),
+            "Vector".sym to GlobalVar("Vector".sym, VectorMeta),
+            "Record".sym to GlobalVar("Record".sym, RecordMeta),
+            "Set".sym to GlobalVar("Set".sym, SetMeta),
+            "Int".sym to GlobalVar("Int".sym, IntMeta),
+            "Double".sym to GlobalVar("Double".sym, DoubleMeta),
+            "String".sym to GlobalVar("String".sym, StringMeta),
+            "BigInt".sym to GlobalVar("BigInt".sym, BigIntMeta),
+            "BigDec".sym to GlobalVar("BigDec".sym, BigDecMeta),
         )
 
         private val anomalyTags = Anomaly.AnomalyMeta.entries.associate { meta ->
             val tagType = TagType("brj.core", meta.tag)
             val type = FnType(listOf(RecordType.notNull()), tagType.notNull()).notNull()
-            meta.tag to GlobalVar(meta.tag, meta, type = type)
+            Symbol.intern(meta.tag) to GlobalVar(Symbol.intern(meta.tag), meta, type = type)
         }
 
         fun withBuiltins(language: BridjeLanguage): NsEnv {
@@ -85,8 +89,8 @@ data class NsEnv(
             val spawnFn = BridjeFunction(SpawnNode(language).callTarget)
             val awaitFn = BridjeFunction(AwaitNode(language).callTarget)
             return NsEnv(vars = mapOf(
-                "spawn" to GlobalVar("spawn", spawnFn),
-                "await" to GlobalVar("await", awaitFn),
+                "spawn".sym to GlobalVar("spawn".sym, spawnFn),
+                "await".sym to GlobalVar("await".sym, awaitFn),
             ))
         }
 
@@ -95,39 +99,39 @@ data class NsEnv(
             val str = StringType.notNull()
             val bool = BoolType.notNull()
 
-            fun gv(name: String, node: RootNode, params: List<Type>, ret: Type): Pair<String, GlobalVar> =
+            fun gv(name: Symbol, node: RootNode, params: List<Type>, ret: Type): Pair<Symbol, GlobalVar> =
                 name to GlobalVar(name, BridjeFunction(node.callTarget),
                     type = FnType(params, ret).notNull())
 
             val fileCtorType = FnType(listOf(freshType()), fileTagType).notNull()
             return NsEnv(vars = mapOf(
-                gv("file", FileNode(language), listOf(str), fileTagType),
-                gv("exists?", FsExistsNode(language), listOf(fileTagType), bool),
-                gv("isFile?", FsIsFileNode(language), listOf(fileTagType), bool),
-                gv("isDir?", FsIsDirNode(language), listOf(fileTagType), bool),
-                gv("readString", FsReadStringNode(language), listOf(fileTagType), str),
-                gv("list", FsListNode(language), listOf(fileTagType), VectorType(fileTagType).notNull()),
-                gv("resolve", FsResolveNode(language), listOf(fileTagType, str), fileTagType),
-                gv("name", FsNameNode(language), listOf(fileTagType), str),
-                gv("path", FsPathNode(language), listOf(fileTagType), str),
-                "File" to GlobalVar("File", FileMeta, type = fileCtorType),
+                gv("file".sym, FileNode(language), listOf(str), fileTagType),
+                gv("exists?".sym, FsExistsNode(language), listOf(fileTagType), bool),
+                gv("isFile?".sym, FsIsFileNode(language), listOf(fileTagType), bool),
+                gv("isDir?".sym, FsIsDirNode(language), listOf(fileTagType), bool),
+                gv("readString".sym, FsReadStringNode(language), listOf(fileTagType), str),
+                gv("list".sym, FsListNode(language), listOf(fileTagType), VectorType(fileTagType).notNull()),
+                gv("resolve".sym, FsResolveNode(language), listOf(fileTagType, str), fileTagType),
+                gv("name".sym, FsNameNode(language), listOf(fileTagType), str),
+                gv("path".sym, FsPathNode(language), listOf(fileTagType), str),
+                "File".sym to GlobalVar("File".sym, FileMeta, type = fileCtorType),
             ))
         }
     }
 
-    operator fun get(name: String): GlobalVar? = vars[name]
+    operator fun get(name: Symbol): GlobalVar? = vars[name]
 
-    fun key(name: String): GlobalVar? = keys[name]
+    fun key(name: Symbol): GlobalVar? = keys[name]
 
-    fun effectVar(name: String): GlobalVar? = effectVars[name]
+    fun effectVar(name: Symbol): GlobalVar? = effectVars[name]
 
-    fun defx(name: String, value: Any?, type: Type, meta: BridjeRecord = BridjeRecord.EMPTY): NsEnv =
+    fun defx(name: Symbol, value: Any?, type: Type, meta: BridjeRecord = BridjeRecord.EMPTY): NsEnv =
         copy(effectVars = effectVars + (name to GlobalVar(name, value, meta, type)))
 
-    fun decl(name: String, declaredType: Type): NsEnv =
+    fun decl(name: Symbol, declaredType: Type): NsEnv =
         copy(pendingDecls = pendingDecls + (name to declaredType))
 
-    fun def(name: String, value: Any?, meta: BridjeRecord = BridjeRecord.EMPTY, type: Type? = null): NsEnv {
+    fun def(name: Symbol, value: Any?, meta: BridjeRecord = BridjeRecord.EMPTY, type: Type? = null): NsEnv {
         val declaredType = pendingDecls[name]
         val finalMeta = if (declaredType != null) meta.put("declaredType", declaredType) else meta
         return copy(
@@ -136,23 +140,23 @@ data class NsEnv(
         )
     }
 
-    fun withEffects(name: String, effects: List<GlobalVar>): NsEnv {
+    fun withEffects(name: Symbol, effects: List<GlobalVar>): NsEnv {
         val existing = vars[name] ?: return this
         return copy(vars = vars + (name to GlobalVar(existing.name, existing.value, existing.meta, existing.type, effects)))
     }
 
     fun defInterop(qualifiedName: String, value: Any?, type: Type): NsEnv =
-        copy(interopVars = interopVars + (qualifiedName to GlobalVar(qualifiedName, value, type = type)))
+        copy(interopVars = interopVars + (qualifiedName to GlobalVar(Symbol.intern(qualifiedName), value, type = type)))
 
     fun interopVar(qualifiedName: String): GlobalVar? = interopVars[qualifiedName]
 
-    fun defKey(name: String, value: Any?, meta: BridjeRecord = BridjeRecord.EMPTY, type: Type? = null): NsEnv =
+    fun defKey(name: Symbol, value: Any?, meta: BridjeRecord = BridjeRecord.EMPTY, type: Type? = null): NsEnv =
         copy(keys = keys + (name to GlobalVar(name, value, meta, type)))
 
-    fun defEnum(enumName: String, variantNames: Set<String>): NsEnv =
+    fun defEnum(enumName: Symbol, variantNames: Set<Symbol>): NsEnv =
         copy(enums = enums + (enumName to variantNames))
 
-    fun enumForTag(tagName: String): String? = enums.entries.firstOrNull { tagName in it.value }?.key
+    fun enumForTag(tagName: Symbol): Symbol? = enums.entries.firstOrNull { tagName in it.value }?.key
 
     @ExportMessage
     fun hasLanguage() = true
@@ -168,12 +172,12 @@ data class NsEnv(
 
     @ExportMessage
     @TruffleBoundary
-    fun getMembers(includeInternal: Boolean): Any = BridjeRecord.Keys((vars.keys + keys.keys + effectVars.keys).toTypedArray())
+    fun getMembers(includeInternal: Boolean): Any = BridjeRecord.Keys((vars.keys + keys.keys + effectVars.keys).map { it.name }.toTypedArray())
 
     @ExportMessage
     @TruffleBoundary
     fun isMemberReadable(member: String) =
-        vars.containsKey(member) || keys.containsKey(member) || effectVars.containsKey(member)
+        vars.containsKey(Symbol.intern(member)) || keys.containsKey(Symbol.intern(member)) || effectVars.containsKey(Symbol.intern(member))
             || member == "__test_var_names__"
             || member.startsWith("__var_meta__:")
 
@@ -186,10 +190,10 @@ data class NsEnv(
         }
         if (member.startsWith("__var_meta__:")) {
             val varName = member.removePrefix("__var_meta__:")
-            val gv = vars[varName] ?: throw UnknownIdentifierException.create(member)
+            val gv = vars[Symbol.intern(varName)] ?: throw UnknownIdentifierException.create(member)
             return gv.meta
         }
-        val v = vars[member] ?: keys[member] ?: effectVars[member] ?: throw UnknownIdentifierException.create(member)
+        val v = vars[Symbol.intern(member)] ?: keys[Symbol.intern(member)] ?: effectVars[Symbol.intern(member)] ?: throw UnknownIdentifierException.create(member)
         return v.value ?: throw UnknownIdentifierException.create(member)
     }
 
@@ -199,7 +203,7 @@ data class NsEnv(
             try {
                 val interop = InteropLibrary.getUncached()
                 if (interop.isMemberReadable(gv.meta, "test") && interop.readMember(gv.meta, "test") == true)
-                    gv.name
+                    gv.name.name
                 else null
             } catch (_: Exception) { null }
         }

--- a/language/src/main/kotlin/brj/Reader.kt
+++ b/language/src/main/kotlin/brj/Reader.kt
@@ -5,6 +5,8 @@ import brj.reader.NativeLibraryLoader
 import io.github.treesitter.jtreesitter.Language
 import io.github.treesitter.jtreesitter.Node
 import io.github.treesitter.jtreesitter.Parser
+import brj.runtime.Symbol
+import brj.runtime.sym
 import java.lang.foreign.Arena
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -44,30 +46,30 @@ class Reader private constructor(private val src: Source) {
             "bigint" -> BigIntForm(BigInteger(text!!.dropLast(1)), loc)
             "bigdec" -> BigDecForm(BigDecimal(text!!.dropLast(1)), loc)
             "string" -> StringForm(text!!.drop(1).dropLast(1), loc)
-            "symbol" -> SymbolForm(text!!, loc)
-            "keyword" -> KeywordForm(text!!.drop(1), loc)
+            "symbol" -> SymbolForm(Symbol.intern(text!!), loc)
+            "keyword" -> KeywordForm(Symbol.intern(text!!.drop(1)), loc)
             "qualified_keyword" -> {
                 // :ns/member — drop leading ':', split on '/'
                 val t = text!!.drop(1)
                 val slash = t.indexOf('/')
-                QKeywordForm(t.substring(0, slash), t.substring(slash + 1), loc)
+                QKeywordForm(Symbol.intern(t.substring(0, slash)), Symbol.intern(t.substring(slash + 1)), loc)
             }
-            "dot_symbol" -> DotSymbolForm(text!!.drop(1), loc)
+            "dot_symbol" -> DotSymbolForm(Symbol.intern(text!!.drop(1)), loc)
             "qualified_dot_symbol" -> {
                 // Alias/.member — split on '/.'
                 val t = text!!
                 val slashDot = t.indexOf("/.")
-                QDotSymbolForm(t.substring(0, slashDot), t.substring(slashDot + 2), loc)
+                QDotSymbolForm(Symbol.intern(t.substring(0, slashDot)), Symbol.intern(t.substring(slashDot + 2)), loc)
             }
             "qualified_symbol" -> {
                 val t = text!!
                 val slash = t.indexOf('/')
                 if (slash >= 0) {
-                    QSymbolForm(t.substring(0, slash), t.substring(slash + 1), loc)
+                    QSymbolForm(Symbol.intern(t.substring(0, slash)), Symbol.intern(t.substring(slash + 1)), loc)
                 } else {
                     // Dotted namespace name: split on last dot
                     val lastDot = t.lastIndexOf('.')
-                    QSymbolForm(t.substring(0, lastDot), t.substring(lastDot + 1), loc)
+                    QSymbolForm(Symbol.intern(t.substring(0, lastDot)), Symbol.intern(t.substring(lastDot + 1)), loc)
                 }
             }
 
@@ -94,10 +96,10 @@ class Reader private constructor(private val src: Source) {
                     if (child.type == "block_body") child.namedChildren.map { it.readForm() }
                     else listOf(child.readForm())
                 }
-                ListForm(listOf(SymbolForm(blockName, loc)) + args, loc)
+                ListForm(listOf(SymbolForm(Symbol.intern(blockName), loc)) + args, loc)
             }
 
-            "quote" -> ListForm(listOf(SymbolForm("quote", loc), namedChildren[0].readForm()), loc)
+            "quote" -> ListForm(listOf(SymbolForm("quote".sym, loc), namedChildren[0].readForm()), loc)
             "syntax_quote" -> {
                 val inner = namedChildren[0].readForm()
                 if (inner !is SymbolForm && inner !is QSymbolForm)

--- a/language/src/main/kotlin/brj/analyser/Analyser.kt
+++ b/language/src/main/kotlin/brj/analyser/Analyser.kt
@@ -8,6 +8,8 @@ import brj.runtime.BridjeMacro
 import brj.runtime.BridjeVector
 import brj.runtime.BridjeTagConstructor
 import brj.runtime.BridjeTaggedSingleton
+import brj.runtime.Symbol
+import brj.runtime.sym
 import brj.types.*
 import brj.types.Nullability.*
 import com.oracle.truffle.api.exception.AbstractTruffleException
@@ -125,62 +127,63 @@ data class Analyser(
         object NotFound : SymbolResolution
     }
 
-    private fun resolveSymbol(name: String, loc: SourceSection?): SymbolResolution {
+    private fun resolveSymbol(sym: Symbol, loc: SourceSection?): SymbolResolution {
+        val name = sym.name
         capturedVars[name]?.let { return SymbolResolution.Captured(it) }
         locals[name]?.let { return SymbolResolution.Local(it) }
-        nsEnv.effectVar(name)?.let { return SymbolResolution.Effect(nsEnv.nsDecl?.name, it) }
-        ctx.brjCore.effectVar(name)?.let { return SymbolResolution.Effect("brj.core", it) }
-        nsEnv[name]?.let { return SymbolResolution.Global(nsEnv.nsDecl?.name, it) }
-        ctx.brjCore[name]?.let { return SymbolResolution.Global("brj.core", it) }
+        nsEnv.effectVar(sym)?.let { return SymbolResolution.Effect(nsEnv.nsDecl?.name, it) }
+        ctx.brjCore.effectVar(sym)?.let { return SymbolResolution.Effect("brj.core", it) }
+        nsEnv[sym]?.let { return SymbolResolution.Global(nsEnv.nsDecl?.name, it) }
+        ctx.brjCore[sym]?.let { return SymbolResolution.Global("brj.core", it) }
         nsEnv.imports[name]?.let { return SymbolResolution.Import(it) }
         tryHostLookup(name, loc)?.let { return SymbolResolution.Host(it) }
         return SymbolResolution.NotFound
     }
 
     private fun analyseSymbol(form: SymbolForm): ValueExpr =
-        when (form.name) {
+        when (form.sym.name) {
             "nil" -> NilExpr(form.loc)
             "true" -> BoolExpr(true, form.loc)
             "false" -> BoolExpr(false, form.loc)
 
-            else -> when (val res = resolveSymbol(form.name, form.loc)) {
+            else -> when (val res = resolveSymbol(form.sym, form.loc)) {
                 is SymbolResolution.Captured -> CapturedVarExpr(res.cv.captureIndex, res.cv.outerLocalVar, form.loc)
                 is SymbolResolution.Local -> LocalVarExpr(res.lv, form.loc)
-                is SymbolResolution.Effect -> EffectVarExpr(form.name, res.gv, form.loc)
+                is SymbolResolution.Effect -> EffectVarExpr(form.sym, res.gv, form.loc)
                 is SymbolResolution.Global -> GlobalVarExpr(res.gv, form.loc)
                 is SymbolResolution.Import ->
                     tryHostLookup(res.fqClass, form.loc)?.let { HostConstructorExpr(it, form.loc) }
                         ?: errorExpr("Imported class not found: ${res.fqClass}", form.loc)
                 is SymbolResolution.Host -> HostConstructorExpr(res.obj, form.loc)
-                SymbolResolution.NotFound -> errorExpr("Unknown symbol: ${form.name}", form.loc)
+                SymbolResolution.NotFound -> errorExpr("Unknown symbol: ${form.sym.name}", form.loc)
             }
         }
 
-    private fun resolveKey(name: String): GlobalVar? =
+    private fun resolveKey(name: Symbol): GlobalVar? =
         nsEnv.key(name) ?: ctx.brjCore.key(name)
 
-    private fun resolveQualifiedKey(nsAlias: String, member: String): GlobalVar? {
+    private fun resolveQualifiedKey(nsAlias: String, member: Symbol): GlobalVar? {
         ctx.namespaces[nsAlias]?.key(member)?.let { return it }
         nsEnv.requires[nsAlias]?.key(member)?.let { return it }
         return null
     }
 
     private fun analyseKeyword(form: KeywordForm): ValueExpr =
-        resolveKey(form.name)?.let { GlobalVarExpr(it, form.loc) }
-            ?: errorExpr("Unknown key: :${form.name}", form.loc)
+        resolveKey(form.sym)?.let { GlobalVarExpr(it, form.loc) }
+            ?: errorExpr("Unknown key: :${form.sym.name}", form.loc)
 
     private fun analyseQualifiedKeyword(form: QKeywordForm): ValueExpr =
-        resolveQualifiedKey(form.namespace, form.member)?.let { GlobalVarExpr(it, form.loc) }
+        resolveQualifiedKey(form.ns.name, form.member)?.let { GlobalVarExpr(it, form.loc) }
             ?: errorExpr("Unknown key: $form", form.loc)
 
     private fun analyseQualifiedDotSymbol(form: QDotSymbolForm): ValueExpr =
-        nsEnv.interopVar("${form.namespace}/${form.member}")
+        nsEnv.interopVar("${form.ns.name}/${form.member.name}")
             ?.let { GlobalVarExpr(it, form.loc) }
             ?: errorExpr("Unknown host member: $form", form.loc)
 
     private fun resolveKeyForm(form: Form): GlobalVar? = when (form) {
-        is KeywordForm -> resolveKey(form.name)
-        is QKeywordForm -> resolveQualifiedKey(form.namespace, form.member)
+        is KeywordForm -> resolveKey(form.sym)
+        is QKeywordForm -> resolveQualifiedKey(form.ns.name, form.member)
         else -> null
     }
 
@@ -208,23 +211,23 @@ data class Analyser(
 
     private fun analyseQualifiedSymbol(form: QSymbolForm): ValueExpr {
         // Try Bridje namespace first (fully qualified)
-        ctx.namespaces[form.namespace]?.let { ns ->
+        ctx.namespaces[form.ns.name]?.let { ns ->
             val globalVar = ns[form.member]
-                ?: return errorExpr("Unknown symbol: ${form.member} in namespace ${form.namespace}", form.loc)
+                ?: return errorExpr("Unknown symbol: ${form.member.name} in namespace ${form.ns.name}", form.loc)
             return GlobalVarExpr(globalVar, form.loc)
         }
 
         // Check if namespace is a require alias
-        nsEnv.requires[form.namespace]?.let { ns ->
+        nsEnv.requires[form.ns.name]?.let { ns ->
             val globalVar = ns[form.member]
-                ?: return errorExpr("Unknown symbol: ${form.member} in required namespace ${form.namespace}", form.loc)
+                ?: return errorExpr("Unknown symbol: ${form.member.name} in required namespace ${form.ns.name}", form.loc)
             return GlobalVarExpr(globalVar, form.loc)
         }
 
         // Check for typed interop declarations
-        nsEnv.interopVar("${form.namespace}/${form.member}")?.let { return GlobalVarExpr(it, form.loc) }
+        nsEnv.interopVar("${form.ns.name}/${form.member.name}")?.let { return GlobalVarExpr(it, form.loc) }
 
-        val fqClass = nsEnv.imports[form.namespace] ?: form.namespace
+        val fqClass = nsEnv.imports[form.ns.name] ?: form.ns.name
 
         val hostClass =
             try {
@@ -232,12 +235,12 @@ data class Analyser(
             } catch (_: Exception) {
                 // Namespace lookup failed - try the full qualified name as a Java class
                 // (e.g., java.lang.String where namespace=java.lang, member=String)
-                val fullName = "${form.namespace}.${form.member}"
+                val fullName = "${form.ns.name}.${form.member.name}"
                 tryHostLookup(fullName, form.loc)?.let { return HostConstructorExpr(it, form.loc) }
-                return errorExpr("Unknown namespace: ${form.namespace}", form.loc)
+                return errorExpr("Unknown namespace: ${form.ns.name}", form.loc)
             }
 
-        return HostStaticMethodExpr(hostClass, form.member, form.loc)
+        return HostStaticMethodExpr(hostClass, form.member.name, form.loc)
     }
 
     private fun analyseListValueExpr(form: ListForm): ValueExpr {
@@ -245,7 +248,7 @@ data class Analyser(
         val first = els.firstOrNull() ?: TODO("empty list not supported yet")
 
         return when (first) {
-            is SymbolForm -> when (first.name) {
+            is SymbolForm -> when (first.sym.name) {
                 "let" -> analyseLet(form)
                 "fn" -> analyseFn(form)
                 "do" -> analyseDo(form)
@@ -277,7 +280,8 @@ data class Analyser(
     }
 
     private fun callFormConstructor(name: String, args: List<ValueExpr>, loc: SourceSection?): ValueExpr {
-        val constructor = nsEnv[name] ?: ctx.brjCore[name]
+        val sym = Symbol.intern(name)
+        val constructor = nsEnv[sym] ?: ctx.brjCore[sym]
             ?: return errorExpr("$name constructor not found", loc)
         return CallExpr(GlobalVarExpr(constructor, loc), args, loc)
     }
@@ -310,7 +314,8 @@ data class Analyser(
         }
         flushGroup()
 
-        val concatVar = nsEnv["concat"] ?: ctx.brjCore["concat"]
+        val concatSym = "concat".sym
+        val concatVar = nsEnv[concatSym] ?: ctx.brjCore[concatSym]
             ?: return errorExpr("concat not found", loc)
 
         val concatenated = chunks.fold(VectorExpr(emptyList(), loc) as ValueExpr) { acc, chunk ->
@@ -342,53 +347,65 @@ data class Analyser(
                 callFormConstructor("String", listOf(StringExpr(form.value, form.loc)), form.loc)
 
             is SymbolForm -> {
-                val name = if (form.name.endsWith("#")) {
-                    val baseName = form.name.dropLast(1)
+                val name = if (form.sym.name.endsWith("#")) {
+                    val baseName = form.sym.name.dropLast(1)
                     gensymScope.getOrPut(baseName) { "${baseName}__${ctx.nextGensymId()}" }
                 } else {
-                    form.name
+                    form.sym.name
                 }
-                callFormConstructor("Symbol", listOf(StringExpr(name, form.loc)), form.loc)
+                callFormConstructor(
+                    "SymbolForm",
+                    listOf(callFormConstructor("Symbol", listOf(StringExpr(name, form.loc)), form.loc)),
+                    form.loc
+                )
             }
 
             is KeywordForm ->
-                callFormConstructor("Keyword", listOf(StringExpr(form.name, form.loc)), form.loc)
+                callFormConstructor(
+                    "KeywordForm",
+                    listOf(callFormConstructor("Symbol", listOf(StringExpr(form.sym.name, form.loc)), form.loc)),
+                    form.loc
+                )
 
             is QKeywordForm ->
                 callFormConstructor(
-                    "QKeyword",
+                    "QKeywordForm",
                     listOf(
-                        StringExpr(form.namespace, form.loc),
-                        StringExpr(form.member, form.loc)
+                        callFormConstructor("Symbol", listOf(StringExpr(form.ns.name, form.loc)), form.loc),
+                        callFormConstructor("Symbol", listOf(StringExpr(form.member.name, form.loc)), form.loc)
                     ),
                     form.loc
                 )
 
             is DotSymbolForm ->
-                callFormConstructor("DotSymbol", listOf(StringExpr(form.name, form.loc)), form.loc)
+                callFormConstructor(
+                    "DotSymbolForm",
+                    listOf(callFormConstructor("Symbol", listOf(StringExpr(form.sym.name, form.loc)), form.loc)),
+                    form.loc
+                )
 
             is QDotSymbolForm ->
                 callFormConstructor(
-                    "QDotSymbol",
+                    "QDotSymbolForm",
                     listOf(
-                        StringExpr(form.namespace, form.loc),
-                        StringExpr(form.member, form.loc)
+                        callFormConstructor("Symbol", listOf(StringExpr(form.ns.name, form.loc)), form.loc),
+                        callFormConstructor("Symbol", listOf(StringExpr(form.member.name, form.loc)), form.loc)
                     ),
                     form.loc
                 )
 
             is QSymbolForm -> {
-                val member = if (form.member.endsWith("#")) {
-                    val baseName = form.member.dropLast(1)
+                val member = if (form.member.name.endsWith("#")) {
+                    val baseName = form.member.name.dropLast(1)
                     gensymScope.getOrPut(baseName) { "${baseName}__${ctx.nextGensymId()}" }
                 } else {
-                    form.member
+                    form.member.name
                 }
                 callFormConstructor(
-                    "QSymbol",
+                    "QSymbolForm",
                     listOf(
-                        StringExpr(form.namespace, form.loc),
-                        StringExpr(member, form.loc)
+                        callFormConstructor("Symbol", listOf(StringExpr(form.ns.name, form.loc)), form.loc),
+                        callFormConstructor("Symbol", listOf(StringExpr(member, form.loc)), form.loc)
                     ),
                     form.loc
                 )
@@ -408,37 +425,37 @@ data class Analyser(
     private fun analyseSyntaxQuote(form: SyntaxQuoteForm): ValueExpr {
         val (ns, member, innerLoc) = when (val inner = form.form) {
             is SymbolForm -> {
-                val resolvedNs = when (val res = resolveSymbol(inner.name, inner.loc)) {
+                val resolvedNs = when (val res = resolveSymbol(inner.sym, inner.loc)) {
                     is SymbolResolution.Effect -> res.ns
                     is SymbolResolution.Global -> res.ns
                     is SymbolResolution.Captured, is SymbolResolution.Local ->
-                        return errorExpr("Cannot syntax-quote local: ${inner.name}", form.loc)
+                        return errorExpr("Cannot syntax-quote local: ${inner.sym.name}", form.loc)
                     is SymbolResolution.Import, is SymbolResolution.Host ->
-                        return errorExpr("Cannot syntax-quote host class: ${inner.name}", form.loc)
+                        return errorExpr("Cannot syntax-quote host class: ${inner.sym.name}", form.loc)
                     SymbolResolution.NotFound ->
-                        return errorExpr("Unknown symbol: ${inner.name}", form.loc)
-                } ?: return errorExpr("Cannot syntax-quote: ${inner.name} has no namespace", form.loc)
-                Triple(resolvedNs, inner.name, inner.loc)
+                        return errorExpr("Unknown symbol: ${inner.sym.name}", form.loc)
+                } ?: return errorExpr("Cannot syntax-quote: ${inner.sym.name} has no namespace", form.loc)
+                Triple(resolvedNs, inner.sym.name, inner.loc)
             }
 
             is QSymbolForm -> {
                 val resolvedNs =
-                    ctx.namespaces[inner.namespace]?.takeIf { it[inner.member] != null }?.let { inner.namespace }
-                        ?: nsEnv.requires[inner.namespace]?.let { req ->
+                    ctx.namespaces[inner.ns.name]?.takeIf { it[inner.member] != null }?.let { inner.ns.name }
+                        ?: nsEnv.requires[inner.ns.name]?.let { req ->
                             if (req[inner.member] != null) req.nsDecl?.name else null
                         }
-                        ?: return errorExpr("Unknown symbol: ${inner.namespace}/${inner.member}", form.loc)
-                Triple(resolvedNs, inner.member, inner.loc)
+                        ?: return errorExpr("Unknown symbol: ${inner.ns.name}/${inner.member.name}", form.loc)
+                Triple(resolvedNs, inner.member.name, inner.loc)
             }
 
             else -> return errorExpr("syntax-quote requires a symbol", form.loc)
         }
 
         return callFormConstructor(
-            "QSymbol",
+            "QSymbolForm",
             listOf(
-                StringExpr(ns, innerLoc),
-                StringExpr(member, innerLoc)
+                callFormConstructor("Symbol", listOf(StringExpr(ns, innerLoc)), innerLoc),
+                callFormConstructor("Symbol", listOf(StringExpr(member, innerLoc)), innerLoc)
             ),
             form.loc
         )
@@ -476,11 +493,11 @@ data class Analyser(
 
             // Check if this looks like a pattern (capitalized symbol, nil, lowercase symbol followed by body, or call with capitalized symbol)
             val isPattern = when (patternForm) {
-                is SymbolForm -> patternForm.name[0].isUpperCase() || patternForm.name == "nil" ||
-                    (patternForm.name[0].isLowerCase() && i + 1 < branchForms.size)
+                is SymbolForm -> patternForm.sym.name[0].isUpperCase() || patternForm.sym.name == "nil" ||
+                    (patternForm.sym.name[0].isLowerCase() && i + 1 < branchForms.size)
                 is ListForm -> {
                     val first = patternForm.els.firstOrNull()
-                    first is SymbolForm && first.name[0].isUpperCase()
+                    first is SymbolForm && first.sym.name[0].isUpperCase()
                 }
                 else -> false
             }
@@ -525,20 +542,21 @@ data class Analyser(
             }
 
             if (tagNames.isNotEmpty()) {
-                val enumName = nsEnv.enumForTag(tagNames.first())
-                    ?: ctx.brjCore.enumForTag(tagNames.first())
-                    ?: nsEnv.requires.values.firstNotNullOfOrNull { it.enumForTag(tagNames.first()) }
+                val firstTagSym = Symbol.intern(tagNames.first())
+                val enumName = nsEnv.enumForTag(firstTagSym)
+                    ?: ctx.brjCore.enumForTag(firstTagSym)
+                    ?: nsEnv.requires.values.firstNotNullOfOrNull { it.enumForTag(firstTagSym) }
 
                 if (enumName != null) {
                     val allVariants = nsEnv.enums[enumName]
                         ?: ctx.brjCore.enums[enumName]
                         ?: nsEnv.requires.values.firstNotNullOfOrNull { it.enums[enumName] }
                         ?: emptySet()
-                    val covered = tagNames.toSet()
-                    if (covered.all { it in allVariants }) {
-                        val missing = allVariants - covered
+                    val coveredSyms = tagNames.map { Symbol.intern(it) }.toSet()
+                    if (coveredSyms.all { it in allVariants }) {
+                        val missing = allVariants - coveredSyms
                         if (missing.isNotEmpty()) {
-                            addError("Non-exhaustive case: missing variants ${missing.joinToString(", ")} of enum $enumName", form.loc)
+                            addError("Non-exhaustive case: missing variants ${missing.joinToString(", ")} of enum ${enumName.name}", form.loc)
                         }
                     }
                 }
@@ -549,7 +567,8 @@ data class Analyser(
     }
 
     private fun resolveTag(name: String, loc: SourceSection?): Result<Error, Any> {
-        val globalVar = nsEnv[name] ?: ctx.brjCore[name]
+        val sym = Symbol.intern(name)
+        val globalVar = nsEnv[sym] ?: ctx.brjCore[sym]
             ?: return Result.Err(Error("Unknown tag: $name", loc))
         val value = globalVar.value
             ?: return Result.Err(Error("Tag $name has no value", loc))
@@ -561,7 +580,7 @@ data class Analyser(
         for (el in els) {
             val sym = el as? SymbolForm
                 ?: return Result.Err(Error("case pattern bindings must be symbols", el.loc))
-            names.add(sym.name)
+            names.add(sym.sym.name)
         }
         return Result.Ok(names)
     }
@@ -569,7 +588,7 @@ data class Analyser(
     private fun analyseCaseBranch(patternForm: Form, bodyForm: Form): Result<Error, CaseBranch> =
         when (patternForm) {
             is SymbolForm -> {
-                val name = patternForm.name
+                val name = patternForm.sym.name
                 when {
                     name == "nil" -> {
                         val bodyExpr = analyseValueExpr(bodyForm)
@@ -595,7 +614,7 @@ data class Analyser(
                 if (tagForm == null) {
                     Result.Err(Error("case pattern must start with a tag name", patternForm.loc))
                 } else {
-                    val tagName = tagForm.name
+                    val tagName = tagForm.sym.name
                     if (!tagName[0].isUpperCase()) {
                         Result.Err(Error("case pattern tag must be capitalized: $tagName", tagForm.loc))
                     } else {
@@ -630,9 +649,9 @@ data class Analyser(
         val bodyForms = mutableListOf<Form>()
 
         for (el in els.drop(1)) {
-            if (el is ListForm && el.els.firstOrNull().let { it is SymbolForm && it.name == "catch" }) {
+            if (el is ListForm && el.els.firstOrNull().let { it is SymbolForm && it.sym.name == "catch" }) {
                 catchForm = el
-            } else if (el is ListForm && el.els.firstOrNull().let { it is SymbolForm && it.name == "finally" }) {
+            } else if (el is ListForm && el.els.firstOrNull().let { it is SymbolForm && it.sym.name == "finally" }) {
                 finallyForm = el
             } else {
                 bodyForms.add(el)
@@ -651,11 +670,11 @@ data class Analyser(
             val patternForm = catchEls[i]
 
             val isPattern = when (patternForm) {
-                is SymbolForm -> patternForm.name[0].isUpperCase() || patternForm.name == "nil" ||
-                    (patternForm.name[0].isLowerCase() && i + 1 < catchEls.size)
+                is SymbolForm -> patternForm.sym.name[0].isUpperCase() || patternForm.sym.name == "nil" ||
+                    (patternForm.sym.name[0].isLowerCase() && i + 1 < catchEls.size)
                 is ListForm -> {
                     val first = patternForm.els.firstOrNull()
-                    first is SymbolForm && first.name[0].isUpperCase()
+                    first is SymbolForm && first.sym.name[0].isUpperCase()
                 }
                 else -> false
             }
@@ -721,7 +740,7 @@ data class Analyser(
         val valueForm = bindingEls[1]
 
         val bindingExpr = copy(recurTarget = null).analyseValueExpr(valueForm)
-        val (newAnalyser, localVar) = withLocal(nameForm.name)
+        val (newAnalyser, localVar) = withLocal(nameForm.sym.name)
 
         val bodyExpr = newAnalyser.analyseBindings(bindingEls.drop(2), bodyForms, loc)
 
@@ -787,7 +806,7 @@ data class Analyser(
             val nameForm = bindingEls[i] as? SymbolForm
                 ?: return errorExpr("loop binding name must be a symbol", bindingEls[i].loc)
             val bindingExpr = nonTail.analyseValueExpr(bindingEls[i + 1])
-            val (newAnalyser, localVar) = analyser.withLocal(nameForm.name)
+            val (newAnalyser, localVar) = analyser.withLocal(nameForm.sym.name)
             analyser = newAnalyser
             bindings.add(localVar to bindingExpr)
         }
@@ -818,14 +837,14 @@ data class Analyser(
             ?: return errorExpr("fn requires a signature list (fn-name & params)", form.loc)
 
         val sigEls = sigForm.els
-        val fnName = (sigEls.firstOrNull() as? SymbolForm)?.name
+        val fnName = (sigEls.firstOrNull() as? SymbolForm)?.sym?.name
             ?: return errorExpr("fn signature must start with a name", sigForm.loc)
 
         val params = mutableListOf<String>()
         for (el in sigEls.drop(1)) {
             val sym = el as? SymbolForm
                 ?: return errorExpr("fn parameter must be a symbol", el.loc)
-            params.add(sym.name)
+            params.add(sym.sym.name)
         }
 
         val bodyForms = els.drop(2)
@@ -923,7 +942,7 @@ data class Analyser(
         val inner = analyseValueExprInner(form)
         val meta = form.meta ?: return inner
 
-        val withMetaVar = ctx.brjCore["withMeta"]
+        val withMetaVar = ctx.brjCore["withMeta".sym]
             ?: return errorExpr("withMeta not found in brj.core", form.loc)
 
         return CallExpr(
@@ -950,12 +969,13 @@ data class Analyser(
             else -> when {
                 name[0].isUpperCase() -> {
                     // Check if it's an enum type first
-                    val enumVariants = nsEnv.enums[name] ?: ctx.brjCore.enums[name]
+                    val sym = Symbol.intern(name)
+                    val enumVariants = nsEnv.enums[sym] ?: ctx.brjCore.enums[sym]
                     if (enumVariants != null) {
                         EnumType(name).notNull()
                     } else {
-                        val ns = nsEnv[name]?.let { nsEnv.nsDecl?.name ?: "" }
-                            ?: ctx.brjCore[name]?.let { "brj.core" }
+                        val ns = nsEnv[sym]?.let { nsEnv.nsDecl?.name ?: "" }
+                            ?: ctx.brjCore[sym]?.let { "brj.core" }
                         if (ns != null) {
                             TagType(ns, name).notNull()
                         } else {
@@ -976,7 +996,7 @@ data class Analyser(
     internal fun analyseTypeForm(form: Form, typeVars: Map<String, TypeVar>): Type =
         when (form) {
             is SymbolForm -> {
-                val name = form.name
+                val name = form.sym.name
                 if (name.endsWith("?")) {
                     val inner = analyseTypeSymbol(name.dropLast(1), form.loc, typeVars)
                     Type(NULLABLE, inner.tv, inner.base)
@@ -1000,7 +1020,7 @@ data class Analyser(
             is ListForm -> {
                 val first = form.els.firstOrNull() as? SymbolForm
                     ?: return errorType("Type form must start with a symbol", form.loc)
-                when (first.name) {
+                when (first.sym.name) {
                     "Iterable" -> {
                         val elForm = form.els.getOrNull(1)
                             ?: return errorType("Iterable type requires an element type", form.loc)
@@ -1025,25 +1045,25 @@ data class Analyser(
                         val invariantVariances = args.map { Variance.INVARIANT }
 
                         // Check if it's an enum type
-                        val enumVariants = nsEnv.enums[first.name] ?: ctx.brjCore.enums[first.name]
+                        val enumVariants = nsEnv.enums[first.sym] ?: ctx.brjCore.enums[first.sym]
                         if (enumVariants != null) {
-                            return EnumType(first.name, args, invariantVariances).notNull()
+                            return EnumType(first.sym.name, args, invariantVariances).notNull()
                         }
 
                         // Check if it's a tag name
-                        val tagNs = nsEnv[first.name]?.let { nsEnv.nsDecl?.name ?: "" }
-                            ?: ctx.brjCore[first.name]?.let { "brj.core" }
+                        val tagNs = nsEnv[first.sym]?.let { nsEnv.nsDecl?.name ?: "" }
+                            ?: ctx.brjCore[first.sym]?.let { "brj.core" }
                         if (tagNs != null) {
-                            return TagType(tagNs, first.name, args, invariantVariances).notNull()
+                            return TagType(tagNs, first.sym.name, args, invariantVariances).notNull()
                         }
 
                         // Check if it's an import alias
-                        val fqClass = nsEnv.imports[first.name]
+                        val fqClass = nsEnv.imports[first.sym.name]
                         if (fqClass != null) {
                             return HostType(fqClass, args, invariantVariances).notNull()
                         }
 
-                        errorType("Unsupported type constructor: ${first.name}", form.loc)
+                        errorType("Unsupported type constructor: ${first.sym.name}", form.loc)
                     }
                 }
             }
@@ -1065,9 +1085,9 @@ data class Analyser(
                 // I/EPOCH I — static field
                 val returnType = analyseTypeForm(retForm, typeVars)
                 InteropMember(
-                    qualifiedName = "${specForm.namespace}/${specForm.member}",
-                    importAlias = specForm.namespace,
-                    memberName = specForm.member,
+                    qualifiedName = "${specForm.ns.name}/${specForm.member.name}",
+                    importAlias = specForm.ns.name,
+                    memberName = specForm.member.name,
                     kind = InteropMemberKind.STATIC_FIELD,
                     declaredType = returnType,
                 )
@@ -1075,14 +1095,14 @@ data class Analyser(
 
             specForm is QDotSymbolForm -> {
                 // Alias/.someField Int — instance field
-                val fqClass = nsEnv.imports[specForm.namespace]
-                    ?: return errorExpr("Unknown import alias: ${specForm.namespace}", specForm.loc)
+                val fqClass = nsEnv.imports[specForm.ns.name]
+                    ?: return errorExpr("Unknown import alias: ${specForm.ns.name}", specForm.loc)
                 val receiverType = HostType(fqClass).notNull()
                 val returnType = analyseTypeForm(retForm, typeVars)
                 InteropMember(
-                    qualifiedName = "${specForm.namespace}/${specForm.member}",
-                    importAlias = specForm.namespace,
-                    memberName = specForm.member,
+                    qualifiedName = "${specForm.ns.name}/${specForm.member.name}",
+                    importAlias = specForm.ns.name,
+                    memberName = specForm.member.name,
                     kind = InteropMemberKind.INSTANCE_FIELD,
                     declaredType = FnType(listOf(receiverType), returnType).notNull(),
                 )
@@ -1098,9 +1118,9 @@ data class Analyser(
                     callee is QSymbolForm -> {
                         // I/now() I or I/parse(Str) I — static method
                         InteropMember(
-                            qualifiedName = "${callee.namespace}/${callee.member}",
-                            importAlias = callee.namespace,
-                            memberName = callee.member,
+                            qualifiedName = "${callee.ns.name}/${callee.member.name}",
+                            importAlias = callee.ns.name,
+                            memberName = callee.member.name,
                             kind = InteropMemberKind.STATIC_METHOD,
                             declaredType = FnType(paramTypes, returnType).notNull(),
                         )
@@ -1108,13 +1128,13 @@ data class Analyser(
 
                     callee is QDotSymbolForm -> {
                         // Alias/.toEpochMilli() Int — instance method
-                        val fqClass = nsEnv.imports[callee.namespace]
-                            ?: return errorExpr("Unknown import alias: ${callee.namespace}", callee.loc)
+                        val fqClass = nsEnv.imports[callee.ns.name]
+                            ?: return errorExpr("Unknown import alias: ${callee.ns.name}", callee.loc)
                         val receiverType = HostType(fqClass).notNull()
                         InteropMember(
-                            qualifiedName = "${callee.namespace}/${callee.member}",
-                            importAlias = callee.namespace,
-                            memberName = callee.member,
+                            qualifiedName = "${callee.ns.name}/${callee.member.name}",
+                            importAlias = callee.ns.name,
+                            memberName = callee.member.name,
                             kind = InteropMemberKind.INSTANCE_METHOD,
                             declaredType = FnType(listOf(receiverType) + paramTypes, returnType).notNull(),
                         )
@@ -1141,20 +1161,20 @@ data class Analyser(
                 val names = (0 until sigForm.els.size step 2).map { i ->
                     val kw = sigForm.els[i] as? KeywordForm
                         ?: return errorExpr("record key decl entries must alternate keyword and type", sigForm.els[i].loc)
-                    kw.name
+                    kw.sym
                 }
                 DefKeysExpr(names, form.loc)
             }
 
             // single key: decl: :name Str
             sigForm is KeywordForm -> {
-                DefKeysExpr(listOf(sigForm.name), form.loc)
+                DefKeysExpr(listOf(sigForm.sym), form.loc)
             }
 
             // type variables: decl: [a] identity(a) a
             sigForm is VectorForm -> {
                 val typeVarNames = sigForm.els.map { tvForm ->
-                    (tvForm as? SymbolForm)?.name
+                    (tvForm as? SymbolForm)?.sym?.name
                         ?: return errorExpr("type variable must be a symbol", tvForm.loc)
                 }
                 val typeVars = typeVarNames.associateWith { TypeVar() }
@@ -1191,14 +1211,14 @@ data class Analyser(
                     ?: return errorExpr("decl function requires a return type", loc)
                 val paramTypes = sigForm.els.drop(1).map { analyseTypeForm(it, typeVars) }
                 val returnType = analyseTypeForm(retForm, typeVars)
-                DeclExpr(nameForm.name, FnType(paramTypes, returnType).notNull(), loc)
+                DeclExpr(nameForm.sym, FnType(paramTypes, returnType).notNull(), loc)
             }
 
             sigForm is SymbolForm -> {
                 // decl: x Int — value type declaration
                 val typeForm = forms.getOrNull(1)
                     ?: return errorExpr("decl requires a type", loc)
-                DeclExpr(sigForm.name, analyseTypeForm(typeForm, typeVars), loc)
+                DeclExpr(sigForm.sym, analyseTypeForm(typeForm, typeVars), loc)
             }
 
             else -> errorExpr("decl requires a name or signature", loc)
@@ -1215,16 +1235,16 @@ data class Analyser(
         return when (sigForm) {
             is ListForm -> {
                 // def: foo(a, b) body -> define a function
-                val name = (sigForm.els.firstOrNull() as? SymbolForm)?.name
+                val name = (sigForm.els.firstOrNull() as? SymbolForm)?.sym
                     ?: return errorExpr("def signature must start with a name", sigForm.loc)
                 // Reuse analyseFn by constructing: (fn (name params...) body...)
-                val fnForm = ListForm(listOf(SymbolForm("fn")) + els.drop(1), form.loc)
+                val fnForm = ListForm(listOf(SymbolForm("fn".sym)) + els.drop(1), form.loc)
                 val fnExpr = analyseFn(fnForm)
                 DefExpr(name, fnExpr, metaExpr, form.loc)
             }
             is SymbolForm -> {
                 // def: foo value -> define a value
-                val name = sigForm.name
+                val name = sigForm.sym
                 val valueForm = els.getOrNull(2)
                     ?: return errorExpr("def requires a value", form.loc)
                 val valueExpr = analyseValueExpr(valueForm)
@@ -1242,7 +1262,7 @@ data class Analyser(
         // tag: [t] Just(t) — type variables via leading vector
         if (sigForm is VectorForm) {
             val typeVarNames = sigForm.els.map { tvForm ->
-                (tvForm as? SymbolForm)?.name
+                (tvForm as? SymbolForm)?.sym?.name
                     ?: return errorExpr("type variable must be a symbol", tvForm.loc)
             }
             val innerSigForm = els.getOrNull(2)
@@ -1257,21 +1277,21 @@ data class Analyser(
         return when (sigForm) {
             is SymbolForm -> {
                 // tag: Nothing (nullary)
-                val name = sigForm.name
-                if (!name[0].isUpperCase()) return errorExpr("tag names must be capitalized: $name", sigForm.loc)
+                val name = sigForm.sym
+                if (!name.name[0].isUpperCase()) return errorExpr("tag names must be capitalized: ${name.name}", sigForm.loc)
                 DefTagExpr(name, emptyList(), typeVarNames, loc)
             }
             is ListForm -> {
                 // tag: Just(t) or tag: [t] Just(t)
                 val nameForm = sigForm.els.firstOrNull() as? SymbolForm
                     ?: return errorExpr("tag signature must start with a name", sigForm.loc)
-                val name = nameForm.name
-                if (!name[0].isUpperCase()) return errorExpr("tag names must be capitalized: $name", nameForm.loc)
+                val name = nameForm.sym
+                if (!name.name[0].isUpperCase()) return errorExpr("tag names must be capitalized: ${name.name}", nameForm.loc)
                 val fieldNames = mutableListOf<String>()
                 for (el in sigForm.els.drop(1)) {
                     val sym = el as? SymbolForm
                         ?: return errorExpr("field names must be symbols", el.loc)
-                    fieldNames.add(sym.name)
+                    fieldNames.add(sym.sym.name)
                 }
                 DefTagExpr(name, fieldNames, typeVarNames, loc)
             }
@@ -1285,12 +1305,12 @@ data class Analyser(
             ?: return errorExpr("enum requires a name", form.loc)
 
         val (enumName, typeVarNames) = when (sigForm) {
-            is SymbolForm -> sigForm.name to emptyList<String>()
+            is SymbolForm -> sigForm.sym to emptyList<String>()
             is ListForm -> {
-                val name = (sigForm.els.firstOrNull() as? SymbolForm)?.name
+                val name = (sigForm.els.firstOrNull() as? SymbolForm)?.sym
                     ?: return errorExpr("enum name must be a symbol", sigForm.loc)
                 val tvs = sigForm.els.drop(1).map { tvForm ->
-                    (tvForm as? SymbolForm)?.name
+                    (tvForm as? SymbolForm)?.sym?.name
                         ?: return errorExpr("type variable must be a symbol", tvForm.loc)
                 }
                 name to tvs
@@ -1298,7 +1318,7 @@ data class Analyser(
             else -> return errorExpr("enum requires a name", sigForm.loc)
         }
 
-        if (!enumName[0].isUpperCase()) return errorExpr("enum names must be capitalized: $enumName", sigForm.loc)
+        if (!enumName.name[0].isUpperCase()) return errorExpr("enum names must be capitalized: ${enumName.name}", sigForm.loc)
 
         val variants = mutableListOf<DefTagExpr>()
         for (nested in els.drop(2)) {
@@ -1307,8 +1327,8 @@ data class Analyser(
                 continue
             }
             val first = nested.els.firstOrNull() as? SymbolForm
-            if (first?.name != "tag") {
-                errorExpr("enum variants must be tag: forms, got: ${first?.name}", nested.loc)
+            if (first?.sym?.name != "tag") {
+                errorExpr("enum variants must be tag: forms, got: ${first?.sym?.name}", nested.loc)
                 continue
             }
             val tagSigForm = nested.els.getOrNull(1)
@@ -1334,7 +1354,7 @@ data class Analyser(
             ?: return errorExpr("defmacro requires a signature: defmacro: name(params)", form.loc)
 
         val sigEls = sigForm.els
-        val name = (sigEls.firstOrNull() as? SymbolForm)?.name
+        val name = (sigEls.firstOrNull() as? SymbolForm)?.sym
             ?: return errorExpr("defmacro signature must start with a name", sigForm.loc)
 
         val params = mutableListOf<String>()
@@ -1343,16 +1363,16 @@ data class Analyser(
         for ((i, el) in paramForms.withIndex()) {
             val sym = el as? SymbolForm
                 ?: return errorExpr("defmacro parameter must be a symbol", el.loc)
-            if (sym.name == "&") {
+            if (sym.sym.name == "&") {
                 val restSym = paramForms.getOrNull(i + 1) as? SymbolForm
                     ?: return errorExpr("& must be followed by a rest parameter name", el.loc)
                 if (i + 2 < paramForms.size)
                     return errorExpr("& rest parameter must be the last parameter", paramForms[i + 2].loc)
-                params.add(restSym.name)
+                params.add(restSym.sym.name)
                 isVariadic = true
                 break
             }
-            params.add(sym.name)
+            params.add(sym.sym.name)
         }
 
         val bodyForms = els.drop(2)
@@ -1368,7 +1388,7 @@ data class Analyser(
 
         val bodyExpr = macroAnalyser.analyseBody(bodyForms, form.loc)
 
-        return DefMacroExpr(name, FnExpr(name, paramLvs, bodyExpr, macroAnalyser.slotCount, emptyList(), isVariadic, form.loc), form.loc)
+        return DefMacroExpr(name, FnExpr(name.name, paramLvs, bodyExpr, macroAnalyser.slotCount, emptyList(), isVariadic, form.loc), form.loc)
     }
 
     private fun analyseDefx(form: ListForm): Expr {
@@ -1379,7 +1399,7 @@ data class Analyser(
             ?: return errorExpr("defx requires a type", form.loc)
         val type = analyseTypeForm(typeForm)
         val defaultExpr = els.getOrNull(3)?.let { analyseValueExpr(it) }
-        return DefxExpr(nameForm.name, type, defaultExpr, form.loc)
+        return DefxExpr(nameForm.sym, type, defaultExpr, form.loc)
     }
 
     private fun analyseWithFx(form: ListForm): ValueExpr {
@@ -1394,9 +1414,9 @@ data class Analyser(
         for (i in bindingEls.indices step 2) {
             val nameForm = bindingEls[i] as? SymbolForm
                 ?: return errorExpr("withFx binding name must be a symbol", bindingEls[i].loc)
-            val effectVar = nsEnv.effectVar(nameForm.name)
-                ?: ctx.brjCore.effectVar(nameForm.name)
-                ?: return errorExpr("Unknown effect: ${nameForm.name}", nameForm.loc)
+            val effectVar = nsEnv.effectVar(nameForm.sym)
+                ?: ctx.brjCore.effectVar(nameForm.sym)
+                ?: return errorExpr("Unknown effect: ${nameForm.sym.name}", nameForm.loc)
             bindings.add(effectVar to analyseValueExpr(bindingEls[i + 1]))
         }
 
@@ -1411,7 +1431,7 @@ data class Analyser(
         if (form is ListForm) {
             val first = form.els.firstOrNull()
             if (first is SymbolForm) {
-                when (first.name) {
+                when (first.sym.name) {
                     "do" -> return TopLevelDo(form.els.drop(1), form.loc)
                     "def" -> return analyseDef(form)
                     "decl" -> return analyseDecl(form)

--- a/language/src/main/kotlin/brj/analyser/Expr.kt
+++ b/language/src/main/kotlin/brj/analyser/Expr.kt
@@ -2,6 +2,7 @@ package brj.analyser
 
 import brj.Form
 import brj.GlobalVar
+import brj.runtime.Symbol
 import brj.types.Type
 import com.oracle.truffle.api.source.SourceSection
 
@@ -11,7 +12,7 @@ sealed interface Expr {
 }
 
 class DefExpr(
-    val name: String,
+    val name: Symbol,
     val valueExpr: ValueExpr,
     val metaExpr: ValueExpr? = null,
     override val loc: SourceSection? = null
@@ -20,7 +21,7 @@ class DefExpr(
 }
 
 class DefTagExpr(
-    val name: String,
+    val name: Symbol,
     val fieldNames: List<String>,
     val typeVarNames: List<String> = emptyList(),
     override val loc: SourceSection? = null
@@ -31,7 +32,7 @@ class DefTagExpr(
 }
 
 class DefEnumExpr(
-    val name: String,
+    val name: Symbol,
     val typeVarNames: List<String>,
     val variants: List<DefTagExpr>,
     override val loc: SourceSection? = null
@@ -41,7 +42,7 @@ class DefEnumExpr(
 }
 
 class DefMacroExpr(
-    val name: String,
+    val name: Symbol,
     val fn: FnExpr,
     override val loc: SourceSection? = null
 ) : Expr {
@@ -49,14 +50,14 @@ class DefMacroExpr(
 }
 
 class DefKeysExpr(
-    val names: List<String>,
+    val names: List<Symbol>,
     override val loc: SourceSection? = null
 ) : Expr {
-    override fun toString(): String = "(decl ${names.joinToString(" ") { ".$it" }})"
+    override fun toString(): String = "(decl ${names.joinToString(" ") { ".${it.name}" }})"
 }
 
 class DeclExpr(
-    val name: String,
+    val name: Symbol,
     val declaredType: Type,
     override val loc: SourceSection? = null
 ) : Expr {
@@ -64,7 +65,7 @@ class DeclExpr(
 }
 
 class DefxExpr(
-    val name: String,
+    val name: Symbol,
     val declaredType: Type,
     val defaultExpr: ValueExpr?,
     override val loc: SourceSection? = null

--- a/language/src/main/kotlin/brj/analyser/NsAnalyser.kt
+++ b/language/src/main/kotlin/brj/analyser/NsAnalyser.kt
@@ -5,16 +5,16 @@ import brj.*
 private fun analyseSpec(prefix: String, spec: Form): Pair<String, String> =
     when (spec) {
         is SymbolForm -> {
-            val name = spec.name
+            val name = spec.sym.name
             name to "$prefix.$name"
         }
         is ListForm -> {
-            if ((spec.els.firstOrNull() as? SymbolForm)?.name != "as") {
+            if ((spec.els.firstOrNull() as? SymbolForm)?.sym?.name != "as") {
                 error("spec list must be an 'as' form: $spec")
             }
-            val name = (spec.els.getOrNull(1) as? SymbolForm)?.name
+            val name = (spec.els.getOrNull(1) as? SymbolForm)?.sym?.name
                 ?: error("as requires name: $spec")
-            val alias = (spec.els.getOrNull(2) as? SymbolForm)?.name
+            val alias = (spec.els.getOrNull(2) as? SymbolForm)?.sym?.name
                 ?: error("as requires alias: $spec")
             alias to "$prefix.$name"
         }
@@ -27,7 +27,7 @@ private fun analysePackagedClause(clauseForm: ListForm): Map<String, String> {
     for (packageForm in clauseForm.els.drop(1)) {
         if (packageForm !is ListForm) error("package group must be a list: $packageForm")
 
-        val prefix = (packageForm.els.firstOrNull() as? SymbolForm)?.name
+        val prefix = (packageForm.els.firstOrNull() as? SymbolForm)?.sym?.name
             ?: error("package group must start with package name: $packageForm")
 
         for (spec in packageForm.els.drop(1)) {
@@ -44,11 +44,11 @@ fun List<Form>.analyseNs(): Pair<NsDecl?, List<Form>> {
     if (first !is ListForm) return Pair(null, this)
 
     val els = first.els
-    if ((els.firstOrNull() as? SymbolForm)?.name != "ns") return Pair(null, this)
+    if ((els.firstOrNull() as? SymbolForm)?.sym?.name != "ns") return Pair(null, this)
 
     val nsName = when (val nameForm = els.getOrNull(1)) {
-        is SymbolForm -> nameForm.name
-        is QSymbolForm -> "${nameForm.namespace}.${nameForm.member}"
+        is SymbolForm -> nameForm.sym.name
+        is QSymbolForm -> "${nameForm.ns.name}.${nameForm.member.name}"
         else -> error("ns requires a name")
     }
 
@@ -57,7 +57,7 @@ fun List<Form>.analyseNs(): Pair<NsDecl?, List<Form>> {
 
     for (clause in els.drop(2)) {
         if (clause !is ListForm) error("ns clause must be a list: $clause")
-        val clauseName = (clause.els.firstOrNull() as? SymbolForm)?.name
+        val clauseName = (clause.els.firstOrNull() as? SymbolForm)?.sym?.name
             ?: error("ns clause must start with a symbol: $clause")
 
         when (clauseName) {

--- a/language/src/main/kotlin/brj/analyser/ValueExpr.kt
+++ b/language/src/main/kotlin/brj/analyser/ValueExpr.kt
@@ -1,6 +1,7 @@
 package brj.analyser
 
 import brj.*
+import brj.runtime.Symbol
 
 import com.oracle.truffle.api.interop.TruffleObject
 import com.oracle.truffle.api.source.SourceSection
@@ -119,7 +120,7 @@ class GlobalVarExpr(
     val globalVar: GlobalVar,
     override val loc: SourceSection? = null
 ) : ValueExpr {
-    override fun toString(): String = globalVar.name
+    override fun toString(): String = globalVar.name.name
 }
 
 class TruffleObjectExpr(
@@ -207,11 +208,11 @@ class RecordSetExpr(
 }
 
 class EffectVarExpr(
-    val name: String,
+    val name: Symbol,
     val effectVar: GlobalVar,
     override val loc: SourceSection? = null
 ) : ValueExpr {
-    override fun toString(): String = name
+    override fun toString(): String = name.name
 }
 
 class WithFxExpr(
@@ -220,7 +221,7 @@ class WithFxExpr(
     override val loc: SourceSection? = null
 ) : ValueExpr {
     override fun toString(): String {
-        val bindingsStr = bindings.joinToString(" ") { (gv, expr) -> "${gv.name} $expr" }
+        val bindingsStr = bindings.joinToString(" ") { (gv, expr) -> "${gv.name.name} $expr" }
         return "(withFx [$bindingsStr] $bodyExpr)"
     }
 }

--- a/language/src/main/kotlin/brj/builtins/Builtins.kt
+++ b/language/src/main/kotlin/brj/builtins/Builtins.kt
@@ -3,12 +3,13 @@ package brj.builtins
 import brj.BridjeLanguage
 import brj.GlobalVar
 import brj.runtime.BridjeFunction
+import brj.runtime.Symbol
 import brj.types.*
 import brj.types.Type
 import com.oracle.truffle.api.nodes.RootNode
 
 object Builtins {
-    fun createBuiltinFunctions(language: BridjeLanguage): Map<String, GlobalVar> {
+    fun createBuiltinFunctions(language: BridjeLanguage): Map<Symbol, GlobalVar> {
         fun numericBinOp(name: String, node: RootNode): GlobalVar {
             val t = freshType()
             return createBuiltinFunction(name, node, FnType(listOf(t, t), t).notNull())
@@ -57,5 +58,5 @@ object Builtins {
     }
 
     private fun createBuiltinFunction(name: String, node: RootNode, type: Type) =
-        GlobalVar(name, BridjeFunction(node.callTarget), type = type)
+        GlobalVar(Symbol.intern(name), BridjeFunction(node.callTarget), type = type)
 }

--- a/language/src/main/kotlin/brj/builtins/GensymNode.kt
+++ b/language/src/main/kotlin/brj/builtins/GensymNode.kt
@@ -3,6 +3,7 @@ package brj.builtins
 import brj.BridjeLanguage
 import brj.SymbolForm
 import brj.runtime.BridjeContext
+import brj.runtime.Symbol
 import com.oracle.truffle.api.frame.VirtualFrame
 import com.oracle.truffle.api.nodes.RootNode
 
@@ -21,6 +22,6 @@ class GensymNode(language: BridjeLanguage) : RootNode(language) {
             "G"
         }
 
-        return SymbolForm("${prefix}__${id}")
+        return SymbolForm(Symbol.intern("${prefix}__${id}"))
     }
 }

--- a/language/src/main/kotlin/brj/builtins/VarMetaNode.kt
+++ b/language/src/main/kotlin/brj/builtins/VarMetaNode.kt
@@ -17,10 +17,10 @@ class VarMetaNode(language: BridjeLanguage) : RootNode(language) {
             ?: throw incorrect("varMeta: expected a qualified symbol, got ${arg?.let { it::class.simpleName }}", this)
 
         val ctx = BridjeContext.get(this)
-        val nsEnv = ctx.namespaces[qsym.namespace]
-            ?: throw incorrect("varMeta: namespace not found: ${qsym.namespace}", this)
+        val nsEnv = ctx.namespaces[qsym.ns.name]
+            ?: throw incorrect("varMeta: namespace not found: ${qsym.ns.name}", this)
         val gv = nsEnv[qsym.member] ?: nsEnv.effectVar(qsym.member)
-            ?: throw incorrect("varMeta: var not found: ${qsym.namespace}/${qsym.member}", this)
+            ?: throw incorrect("varMeta: var not found: ${qsym.ns.name}/${qsym.member.name}", this)
 
         return gv.meta
     }

--- a/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
+++ b/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
@@ -135,9 +135,9 @@ class ParseRootNode(
     private fun evalDefTag(expr: DefTagExpr, nsEnv: NsEnv, enumName: String? = null): Pair<Any, NsEnv> {
         val value: Any =
             if (expr.fieldNames.isEmpty()) {
-                BridjeTaggedSingleton(expr.name)
+                BridjeTaggedSingleton(expr.name.name)
             } else {
-                BridjeTagConstructor(expr.name, expr.fieldNames.size, expr.fieldNames)
+                BridjeTagConstructor(expr.name.name, expr.fieldNames.size, expr.fieldNames)
             }
 
         val ns = nsEnv.nsDecl?.name ?: ""
@@ -151,7 +151,7 @@ class ParseRootNode(
             } else if (enumName != null) {
                 EnumType(enumName).notNull()
             } else {
-                TagType(ns, expr.name).notNull()
+                TagType(ns, expr.name.name).notNull()
             }
         } else {
             val typeVars = expr.typeVarNames.associateWith { TypeVar() }
@@ -164,7 +164,7 @@ class ParseRootNode(
             val returnType = if (enumName != null) {
                 EnumType(enumName, tagArgs, variances)
             } else {
-                TagType(ns, expr.name, tagArgs, variances)
+                TagType(ns, expr.name.name, tagArgs, variances)
             }
             FnType(fieldTypes, returnType.notNull()).notNull()
         }
@@ -214,10 +214,10 @@ class ParseRootNode(
                 }
 
                 is DefEnumExpr -> {
-                    val variantNames = mutableSetOf<String>()
+                    val variantNames = mutableSetOf<Symbol>()
                     var lastValue: Any? = null
                     for (tagExpr in expr.variants) {
-                        val (value, updatedNsEnv) = evalDefTag(tagExpr, nsEnv, enumName = expr.name)
+                        val (value, updatedNsEnv) = evalDefTag(tagExpr, nsEnv, enumName = expr.name.name)
                         nsEnv = updatedNsEnv
                         variantNames.add(tagExpr.name)
                         lastValue = value
@@ -294,12 +294,13 @@ class ParseRootNode(
                 is DefKeysExpr -> {
                     var lastKey: BridjeKey? = null
                     for (name in expr.names) {
-                        val key = BridjeKey(name)
+                        val key = BridjeKey(name.name)
                         val keyType = FnType(listOf(RecordType.notNull()), freshType()).notNull()
                         val optKeyType = FnType(listOf(RecordType.notNull()), freshType()).notNull()
+                        val optName = Symbol.intern("?${name.name}")
                         nsEnv = nsEnv.defKey(name, key, type = keyType)
-                        nsEnv = nsEnv.defKey("?$name", BridjeOptionalKey(name), type = optKeyType)
-                        nsEnv = nsEnv.def("?$name", BridjeOptionalKey(name), type = optKeyType)
+                        nsEnv = nsEnv.defKey(optName, BridjeOptionalKey(name.name), type = optKeyType)
+                        nsEnv = nsEnv.def(optName, BridjeOptionalKey(name.name), type = optKeyType)
                         lastKey = key
                     }
                     lastKey

--- a/language/src/main/kotlin/brj/runtime/BridjeFile.kt
+++ b/language/src/main/kotlin/brj/runtime/BridjeFile.kt
@@ -31,7 +31,7 @@ class BridjeFile(@JvmField val truffleFile: TruffleFile) : TruffleObject {
     fun toDisplayString(allowSideEffects: Boolean): String = "File(${truffleFile.path})"
 }
 
-object FileMeta : BuiltinMetaObj("File", "brj.fs") {
+object FileMeta : BuiltinMetaObj("File".sym, "brj.fs".sym) {
     override fun isMetaInstance(instance: Any?) = instance is BridjeFile
 
     override fun execute(arguments: Array<Any?>): Any {

--- a/language/src/main/kotlin/brj/runtime/BuiltinMetaObj.kt
+++ b/language/src/main/kotlin/brj/runtime/BuiltinMetaObj.kt
@@ -8,9 +8,9 @@ import com.oracle.truffle.api.library.ExportMessage
 import com.oracle.truffle.api.strings.TruffleString
 
 @ExportLibrary(InteropLibrary::class)
-abstract class BuiltinMetaObj(val tagName: String, val ns: String) : TruffleObject {
-    private val fqName: String = "$ns/$tagName"
-    private val tagString: TruffleString = TruffleString.fromConstant(tagName, TruffleString.Encoding.UTF_8)
+abstract class BuiltinMetaObj(val tagName: Symbol, val ns: Symbol) : TruffleObject {
+    private val fqName: String = "${ns.name}/${tagName.name}"
+    private val tagString: TruffleString = TruffleString.fromConstant(tagName.name, TruffleString.Encoding.UTF_8)
     private val fqTagString: TruffleString = TruffleString.fromConstant(fqName, TruffleString.Encoding.UTF_8)
 
     @ExportMessage fun isMetaObject() = true

--- a/language/src/main/kotlin/brj/runtime/Symbol.kt
+++ b/language/src/main/kotlin/brj/runtime/Symbol.kt
@@ -1,0 +1,60 @@
+package brj.runtime
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary
+import com.oracle.truffle.api.interop.ArityException
+import com.oracle.truffle.api.interop.InteropLibrary
+import com.oracle.truffle.api.interop.InvalidArrayIndexException
+import com.oracle.truffle.api.interop.TruffleObject
+import com.oracle.truffle.api.library.ExportLibrary
+import com.oracle.truffle.api.library.ExportMessage
+import com.oracle.truffle.api.strings.TruffleString
+import java.util.concurrent.ConcurrentHashMap
+
+@ExportLibrary(InteropLibrary::class)
+class Symbol private constructor(val name: String) : TruffleObject {
+
+    private val nameTruffle: TruffleString =
+        TruffleString.fromJavaStringUncached(name, TruffleString.Encoding.UTF_8)
+
+    @ExportMessage fun hasMetaObject() = true
+    @ExportMessage fun getMetaObject(): Any = SymbolMeta
+
+    @ExportMessage fun hasArrayElements() = true
+    @ExportMessage fun getArraySize() = 1L
+    @ExportMessage fun isArrayElementReadable(idx: Long) = idx == 0L
+
+    @ExportMessage
+    @Throws(InvalidArrayIndexException::class)
+    fun readArrayElement(idx: Long): Any {
+        if (idx != 0L) throw InvalidArrayIndexException.create(idx)
+        return nameTruffle
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage
+    @TruffleBoundary
+    fun toDisplayString(allowSideEffects: Boolean): String = name
+
+    override fun toString(): String = name
+
+    companion object {
+        private val INTERNED = ConcurrentHashMap<String, Symbol>()
+
+        @JvmStatic
+        fun intern(name: String): Symbol = INTERNED.computeIfAbsent(name) { Symbol(it) }
+    }
+}
+
+val String.sym: Symbol get() = Symbol.intern(this)
+
+object SymbolMeta : BuiltinMetaObj("Symbol".sym, "brj.core".sym) {
+    override fun isMetaInstance(instance: Any?) = instance is Symbol
+
+    @Throws(ArityException::class)
+    @TruffleBoundary
+    override fun execute(arguments: Array<Any?>): Any {
+        if (arguments.size != 1) throw ArityException.create(1, 1, arguments.size)
+        val name = (arguments[0] as TruffleString).toJavaStringUncached()
+        return Symbol.intern(name)
+    }
+}

--- a/language/src/test/kotlin/brj/FormConstructorTest.kt
+++ b/language/src/test/kotlin/brj/FormConstructorTest.kt
@@ -13,15 +13,22 @@ class FormConstructorTest {
 
     @Test
     fun `List creates ListForm from forms`() = withContext { ctx ->
-        val result = ctx.evalBridje("List([Symbol(\"if\") Symbol(\"true\") Int(1) Int(2)])")
+        val result = ctx.evalBridje("List([SymbolForm(Symbol(\"if\")) SymbolForm(Symbol(\"true\")) Int(1) Int(2)])")
         assertEquals("List", result.metaObject.metaSimpleName)
         assertEquals("(if true 1 2)", result.toString())
     }
 
     @Test
-    fun `Symbol creates SymbolForm from string`() = withContext { ctx ->
+    fun `Symbol creates Symbol value from string`() = withContext { ctx ->
         val result = ctx.evalBridje("Symbol(\"foo\")")
         assertEquals("Symbol", result.metaObject.metaSimpleName)
+        assertEquals("foo", result.toString())
+    }
+
+    @Test
+    fun `SymbolForm wraps Symbol`() = withContext { ctx ->
+        val result = ctx.evalBridje("SymbolForm(Symbol(\"foo\"))")
+        assertEquals("SymbolForm", result.metaObject.metaSimpleName)
         assertEquals("foo", result.toString())
     }
 
@@ -41,7 +48,7 @@ class FormConstructorTest {
 
     @Test
     fun `nested form construction`() = withContext { ctx ->
-        val result = ctx.evalBridje("List([Symbol(\"let\") Vector(['x Int(1)]) Symbol(\"x\")])")
+        val result = ctx.evalBridje("List([SymbolForm(Symbol(\"let\")) Vector(['x Int(1)]) SymbolForm(Symbol(\"x\"))])")
         assertEquals("List", result.metaObject.metaSimpleName)
         assertEquals("(let [x 1] x)", result.toString())
     }
@@ -55,7 +62,7 @@ class FormConstructorTest {
 
     @Test
     fun `Record creates RecordForm`() = withContext { ctx ->
-        val result = ctx.evalBridje("Record([Symbol(\"a\") Int(1)])")
+        val result = ctx.evalBridje("Record([SymbolForm(Symbol(\"a\")) Int(1)])")
         assertEquals("Record", result.metaObject.metaSimpleName)
         assertEquals("{a 1}", result.toString())
     }

--- a/language/src/test/kotlin/brj/MacroTest.kt
+++ b/language/src/test/kotlin/brj/MacroTest.kt
@@ -11,7 +11,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             do:
               defmacro: unless(cond, body)
-                List([Symbol("if") cond 'nil body])
+                List([SymbolForm(Symbol("if")) cond 'nil body])
               unless: false
                 42
         """)
@@ -23,7 +23,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             do:
               defmacro: when(cond, body)
-                List([Symbol("if") cond body 'nil])
+                List([SymbolForm(Symbol("if")) cond body 'nil])
               when: true
                 1
         """)
@@ -35,7 +35,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             do:
               defmacro: when(cond, body)
-                List([Symbol("if") cond body 'nil])
+                List([SymbolForm(Symbol("if")) cond body 'nil])
               when: false
                 1
         """)
@@ -47,7 +47,7 @@ class MacroTest {
         val result1 = ctx.evalBridje("""
             do:
               defmacro: if-not(cond, then, else)
-                List([Symbol("if") cond else then])
+                List([SymbolForm(Symbol("if")) cond else then])
               if-not: false
                 1
                 2

--- a/language/src/test/kotlin/brj/QuoteTest.kt
+++ b/language/src/test/kotlin/brj/QuoteTest.kt
@@ -8,7 +8,7 @@ class QuoteTest {
     @Test
     fun `quote symbol returns SymbolForm`() = withContext { ctx ->
         val result = ctx.evalBridje("'foo")
-        assertEquals("Symbol", result.metaObject.metaSimpleName)
+        assertEquals("SymbolForm", result.metaObject.metaSimpleName)
         assertEquals("foo", result.toString())
     }
 
@@ -51,7 +51,7 @@ class QuoteTest {
     fun `case on quoted symbol`() = withContext { ctx ->
         val result = ctx.evalBridje("""
             case: 'foo
-              Symbol 1
+              SymbolForm 1
               List 2
               3
         """.trimIndent())
@@ -62,7 +62,7 @@ class QuoteTest {
     fun `case on quoted list`() = withContext { ctx ->
         val result = ctx.evalBridje("""
             case: '(a b c)
-              Symbol 1
+              SymbolForm 1
               List 2
               3
         """.trimIndent())
@@ -84,7 +84,7 @@ class QuoteTest {
     fun `case with default on quoted form`() = withContext { ctx ->
         val result = ctx.evalBridje("""
             case: '42
-              Symbol 1
+              SymbolForm 1
               List 2
               99
         """.trimIndent())
@@ -99,7 +99,7 @@ class QuoteTest {
         val forms = result.getArrayElement(0)
         assertTrue(forms.hasArrayElements())
         assertEquals(3L, forms.arraySize)
-        assertEquals("Symbol", forms.getArrayElement(0).metaObject.metaSimpleName)
+        assertEquals("SymbolForm", forms.getArrayElement(0).metaObject.metaSimpleName)
         assertEquals("a", forms.getArrayElement(0).toString())
     }
 
@@ -129,7 +129,7 @@ class QuoteTest {
     @Test
     fun `syntax-quote resolves brj core builtin`() = withContext { ctx ->
         val result = ctx.evalBridje("`count")
-        assertEquals("QSymbol", result.metaObject.metaSimpleName)
+        assertEquals("QSymbolForm",result.metaObject.metaSimpleName)
         assertEquals("brj.core/count", result.toString())
     }
 
@@ -154,7 +154,7 @@ class QuoteTest {
     @Test
     fun `syntax-quote on fully qualified symbol`() = withContext { ctx ->
         val result = ctx.evalBridje("`brj.core/count")
-        assertEquals("QSymbol", result.metaObject.metaSimpleName)
+        assertEquals("QSymbolForm",result.metaObject.metaSimpleName)
         assertEquals("brj.core/count", result.toString())
     }
 
@@ -181,7 +181,7 @@ class QuoteTest {
         """.trimIndent())
 
         val resolved = result.getMember("result")
-        assertEquals("QSymbol", resolved.metaObject.metaSimpleName)
+        assertEquals("QSymbolForm",resolved.metaObject.metaSimpleName)
         assertEquals("foo.lib/bar", resolved.toString())
     }
 }

--- a/language/src/test/kotlin/brj/ReaderTest.kt
+++ b/language/src/test/kotlin/brj/ReaderTest.kt
@@ -1,6 +1,7 @@
 package brj
 
 import brj.Reader.Companion.readForms
+import brj.runtime.Symbol
 import com.oracle.truffle.api.source.Source
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -14,10 +15,10 @@ private fun Form.contentEquals(other: Form): Boolean = when {
     this is BigIntForm && other is BigIntForm -> value == other.value
     this is BigDecForm && other is BigDecForm -> value == other.value
     this is StringForm && other is StringForm -> value == other.value
-    this is SymbolForm && other is SymbolForm -> name == other.name
-    this is KeywordForm && other is KeywordForm -> name == other.name
-    this is QKeywordForm && other is QKeywordForm -> namespace == other.namespace && member == other.member
-    this is QSymbolForm && other is QSymbolForm -> namespace == other.namespace && member == other.member
+    this is SymbolForm && other is SymbolForm -> sym == other.sym
+    this is KeywordForm && other is KeywordForm -> sym == other.sym
+    this is QKeywordForm && other is QKeywordForm -> ns == other.ns && member == other.member
+    this is QSymbolForm && other is QSymbolForm -> ns == other.ns && member == other.member
     this is ListForm && other is ListForm ->
         els.size == other.els.size && els.zip(other.els).all { (a, b) -> a.contentEquals(b) }
     this is VectorForm && other is VectorForm ->
@@ -29,9 +30,9 @@ private fun Form.contentEquals(other: Form): Boolean = when {
     else -> false
 }
 
-private fun sym(name: String) = SymbolForm(name)
-private fun kw(name: String) = KeywordForm(name)
-private fun qsym(ns: String, member: String) = QSymbolForm(ns, member)
+private fun sym(name: String) = SymbolForm(Symbol.intern(name))
+private fun kw(name: String) = KeywordForm(Symbol.intern(name))
+private fun qsym(ns: String, member: String) = QSymbolForm(Symbol.intern(ns), Symbol.intern(member))
 private fun int(value: Long) = IntForm(value)
 private fun list(vararg els: Form) = ListForm(els.toList())
 private fun vec(vararg els: Form) = VectorForm(els.toList())

--- a/language/src/test/kotlin/brj/SymbolTest.kt
+++ b/language/src/test/kotlin/brj/SymbolTest.kt
@@ -1,0 +1,22 @@
+package brj
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class SymbolTest {
+
+    @Test
+    fun `Symbol from Bridje constructs a Symbol value`() = withContext { ctx ->
+        val result = ctx.evalBridje("Symbol(\"foo\")")
+        assertEquals("Symbol", result.metaObject.metaSimpleName)
+        assertEquals("foo", result.toString())
+    }
+
+    @Test
+    fun `Symbol destructures as tagged tuple with name element`() = withContext { ctx ->
+        val result = ctx.evalBridje("Symbol(\"foo\")")
+        assertTrue(result.hasArrayElements(), "Symbol should expose array elements")
+        assertEquals(1L, result.arraySize)
+        assertEquals("foo", result.getArrayElement(0).asString())
+    }
+}

--- a/language/src/test/kotlin/brj/types/TypeTest.kt
+++ b/language/src/test/kotlin/brj/types/TypeTest.kt
@@ -2,6 +2,7 @@ package brj.types
 
 import brj.*
 import brj.analyser.*
+import brj.runtime.sym
 import brj.types.Nullability.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -217,7 +218,7 @@ class TypeTest {
     fun `global var reads type from GlobalVar`() {
         val tv = TypeVar()
         val fnType = FnType(listOf(Type(NOT_NULL, tv, null)), Type(NOT_NULL, tv, null)).notNull()
-        val gv = GlobalVar("id", null, type = fnType)
+        val gv = GlobalVar("id".sym, null, type = fnType)
         val type = GlobalVarExpr(gv).checkType()
         val fn = type.base as FnType
         assertEquals(fn.paramTypes[0].tv, fn.returnType.tv)
@@ -226,7 +227,7 @@ class TypeTest {
 
     @Test
     fun `global var with no type returns fresh`() {
-        val type = GlobalVarExpr(GlobalVar("x", 42)).checkType()
+        val type = GlobalVarExpr(GlobalVar("x".sym, 42)).checkType()
         assertNotNull(type)
     }
 
@@ -245,7 +246,7 @@ class TypeTest {
         // fn is Fn([?, Record] ?) — give opts a Record type by using it in a record position
         // Simpler: just use a GlobalVar with a known FnType
         val fnType = FnType(listOf(StringType.notNull(), RecordType.notNull()), IntType.notNull()).notNull()
-        val gv = GlobalVar("open", null, type = fnType)
+        val gv = GlobalVar("open".sym, null, type = fnType)
         val type = CallExpr(GlobalVarExpr(gv), listOf(StringExpr("hello"))).checkType()
         assertEquals(IntType, type.base)
     }
@@ -253,7 +254,7 @@ class TypeTest {
     @Test
     fun `call fn without trailing Record param but pass a record`() {
         val fnType = FnType(listOf(StringType.notNull()), IntType.notNull()).notNull()
-        val gv = GlobalVar("simple", null, type = fnType)
+        val gv = GlobalVar("simple".sym, null, type = fnType)
         val type = CallExpr(GlobalVarExpr(gv), listOf(StringExpr("hello"), RecordExpr(emptyList()))).checkType()
         assertEquals(IntType, type.base)
     }
@@ -261,7 +262,7 @@ class TypeTest {
     @Test
     fun `call fn with trailing Record param passing the record`() {
         val fnType = FnType(listOf(StringType.notNull(), RecordType.notNull()), IntType.notNull()).notNull()
-        val gv = GlobalVar("open", null, type = fnType)
+        val gv = GlobalVar("open".sym, null, type = fnType)
         val type = CallExpr(GlobalVarExpr(gv), listOf(StringExpr("hello"), RecordExpr(emptyList()))).checkType()
         assertEquals(IntType, type.base)
     }
@@ -269,7 +270,7 @@ class TypeTest {
     @Test
     fun `call fn with trailing non-Record extra arg still fails`() {
         val fnType = FnType(listOf(StringType.notNull()), IntType.notNull()).notNull()
-        val gv = GlobalVar("simple", null, type = fnType)
+        val gv = GlobalVar("simple".sym, null, type = fnType)
         assertThrows(TypeErrorException::class.java) {
             CallExpr(GlobalVarExpr(gv), listOf(StringExpr("hello"), IntExpr(42))).checkType()
         }
@@ -279,8 +280,8 @@ class TypeTest {
     fun `if branches with different fn arities - trailing record - joins to shorter`() {
         val fnWithRecord = FnType(listOf(StringType.notNull(), RecordType.notNull()), IntType.notNull()).notNull()
         val fnWithout = FnType(listOf(StringType.notNull()), IntType.notNull()).notNull()
-        val gv1 = GlobalVar("open", null, type = fnWithRecord)
-        val gv2 = GlobalVar("openFast", null, type = fnWithout)
+        val gv1 = GlobalVar("open".sym, null, type = fnWithRecord)
+        val gv2 = GlobalVar("openFast".sym, null, type = fnWithout)
         val type = IfExpr(BoolExpr(true), GlobalVarExpr(gv1), GlobalVarExpr(gv2)).checkType()
         val fn = type.base as FnType
         assertEquals(1, fn.paramTypes.size)


### PR DESCRIPTION
Names were raw `String` everywhere a Bridje identifier lived — on forms, in `NsEnv.vars`, on `GlobalVar`, in every analyser signature.
`String` means "any string", so nothing stopped a typo, a namespace-string, or a host-interop key from appearing where an identifier was expected.
`Symbol` is now a first-class, interned runtime value that fills that role.

## Deviation from Clojure: one name only

Clojure's Symbol carries an optional namespace.
Bridje already splits qualified vs unqualified at the form-type level (`SymbolForm` vs `QSymbolForm`, same for Keyword/DotSymbol), so putting qualification inside Symbol too would duplicate it.
`QSymbolForm` now holds two Symbols, `SymbolForm` holds one, and destructuring stays clean.

## User-facing

`Symbol("foo")` from Bridje constructs a Symbol value — it's a built-in tag with the name as its single field, so `case s Symbol(n) -> n` works.
`SymbolForm(Symbol("foo"))` wraps a Symbol into a form.
The display names on form metas were renamed (`"Symbol"` → `"SymbolForm"`, etc.) to disambiguate from the new Symbol value ctor — previously both would have reported `metaSimpleName == "Symbol"`.
The old bare-name aliases (`"Symbol"/"QSymbol"/...` as shortcuts for the form ctors) were removed; no `.brj` files referenced them.

## Reach

`NsEnv.vars` / `keys` / `effectVars` / `pendingDecls` / `enums` → `Map<Symbol, _>`.
`GlobalVar.name: Symbol`.
Every `Expr` carrying a def/decl/effect name flips.
`BuiltinMetaObj(tagName, ns)` takes Symbols — 20+ tag-meta singletons all pass `.sym`.

`requires` / `imports` / `interopVars` stay String-keyed — those are parser-level aliases and host-interop composite keys (`"ns/member"`), not Bridje identifiers.

## Interning

Global static `ConcurrentHashMap` in `Symbol.Companion`.
Per-context was rejected because forms get constructed from places where no `BridjeContext` is in scope — tests, static meta objects, `Form.copy()`.
Memory is bounded by the set of identifiers across programs — same shape as `TruffleString.fromConstant`.

## Ergonomics

`val String.sym: Symbol` extension for Kotlin-side literals: `"foo".sym`.
Used throughout. `Symbol.intern(expr)` for non-literal expressions.

## Out of scope

`case: x SymbolForm(s) -> s` destructuring doesn't match the new form types yet — the case machinery currently only binds fields on `BridjeTagConstructor` tags, not `BuiltinMetaObj` ones.
A test was drafted and dropped; enabling form destructuring needs its own PR.

## Test plan

- [x] All 561 tests pass (up from 558 baseline: 3 new in `SymbolTest`).
- [x] `varMeta(\`brj.core/count)` still resolves through the flipped `NsEnv` map.
- [x] Backtick syntax-quote produces `QSymbolForm` with two interned Symbols.