### PR TITLE
feat: lang: value-position form for polyglot calls

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ shadow = { id = "com.gradleup.shadow", version = "9.3.1" }
 
 [libraries]
 graal-sdk = { module = "org.graalvm.sdk:graal-sdk", version.ref = "graalvm" }
+graal-js = { module = "org.graalvm.js:js-community", version.ref = "graalvm" }
 truffle-runtime = { module = "org.graalvm.truffle:truffle-runtime", version.ref = "graalvm" }
 truffle-api = { module = "org.graalvm.truffle:truffle-api", version.ref = "graalvm" }
 truffle-dsl-processor = { module = "org.graalvm.truffle:truffle-dsl-processor", version.ref = "graalvm" }

--- a/language/build.gradle.kts
+++ b/language/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.graal.js)
 }
 
 sourceSets {

--- a/language/src/main/kotlin/brj/Emitter.kt
+++ b/language/src/main/kotlin/brj/Emitter.kt
@@ -4,10 +4,12 @@ import brj.analyser.*
 import brj.effects.collectEffectfulCallees
 import brj.effects.inferEffects
 import brj.nodes.*
+import brj.runtime.BridjeContext
 import brj.runtime.BridjeFxMap
 import brj.runtime.BridjeFunction
 import brj.runtime.HostClass
 import brj.runtime.BridjeNull
+import com.oracle.truffle.api.source.Source
 import com.oracle.truffle.api.Truffle
 import com.oracle.truffle.api.dsl.TypeSystemReference
 import com.oracle.truffle.api.frame.FrameDescriptor
@@ -96,7 +98,7 @@ data class CapturedNodeSource(val captureIndex: Int) : NodeSource {
     override fun captureSource() = TransitiveCapture(captureIndex)
 }
 
-class Emitter(private val language: BridjeLanguage) {
+class Emitter(private val language: BridjeLanguage, private val ctx: BridjeContext) {
     var nextSlot: Int = 0
 
     fun allocSlot(): Int = nextSlot++
@@ -146,8 +148,15 @@ class Emitter(private val language: BridjeLanguage) {
         is WithFxExpr -> emitWithFx(expr, fxSource, preApplied)
         is LoopExpr -> emitLoop(expr, fxSource, preApplied)
         is RecurExpr -> RecurNode(expr.argExprs.map { emitExpr(it, fxSource, preApplied) }.toTypedArray(), expr.loc)
+        is LangExpr -> emitLang(expr)
 
         is ErrorValueExpr -> error("analyser error: ${expr.message}")
+    }
+
+    private fun emitLang(expr: LangExpr): BridjeNode {
+        val source = Source.newBuilder(expr.language, expr.code, "lang-${expr.language}").build()
+        val value = ctx.truffleEnv.parsePublic(source).call()
+        return LangNode(value, expr.loc)
     }
 
     private fun emitCall(expr: CallExpr, fxSource: NodeSource?, preApplied: Map<GlobalVar, NodeSource>): BridjeNode {
@@ -303,7 +312,7 @@ class Emitter(private val language: BridjeLanguage) {
         val allCaptureSources = (analyserCaptures + extraCaptures).toTypedArray()
         val hasCapturedValues = allCaptureSources.isNotEmpty()
 
-        val innerEmitter = Emitter(language)
+        val innerEmitter = Emitter(language, ctx)
         innerEmitter.nextSlot = expr.slotCount
         val rawBodyNode = innerEmitter.emitExpr(expr.bodyExpr, innerFxSource, innerPreApplied)
 

--- a/language/src/main/kotlin/brj/analyser/Analyser.kt
+++ b/language/src/main/kotlin/brj/analyser/Analyser.kt
@@ -267,6 +267,7 @@ data class Analyser(
                 "defmacro" -> errorExpr("defmacro not allowed in value position", form.loc)
                 "defkeys" -> errorExpr("defkeys has been replaced: use decl: :name Str", form.loc)
                 "defx" -> errorExpr("defx not allowed in value position", form.loc)
+                "lang" -> analyseLang(form)
                 else -> analyseCall(form)
             }
             else -> analyseCall(form)
@@ -1421,6 +1422,26 @@ data class Analyser(
         val type = analyseTypeForm(typeForm)
         val defaultExpr = els.getOrNull(3)?.let { analyseValueExpr(it) }
         return DefxExpr(nameForm.sym, type, defaultExpr, form.loc)
+    }
+
+    private fun analyseLang(form: ListForm): ValueExpr {
+        val els = form.els
+        val langForm = els.getOrNull(1) as? StringForm
+            ?: return errorExpr("lang requires a language name as a string literal", form.loc)
+        val typeForm = els.getOrNull(2)
+            ?: return errorExpr("lang requires a declared type", form.loc)
+        val codeForm = els.getOrNull(3) as? StringForm
+            ?: return errorExpr("lang requires a code string", form.loc)
+
+        val available = ctx.truffleEnv.publicLanguages.keys
+        if (langForm.value !in available) {
+            return errorExpr(
+                "Language '${langForm.value}' is not available. Available: ${available.sorted()}",
+                langForm.loc,
+            )
+        }
+
+        return LangExpr(langForm.value, analyseTypeForm(typeForm), codeForm.value, form.loc)
     }
 
     private fun analyseWithFx(form: ListForm): ValueExpr {

--- a/language/src/main/kotlin/brj/analyser/ValueExpr.kt
+++ b/language/src/main/kotlin/brj/analyser/ValueExpr.kt
@@ -2,6 +2,7 @@ package brj.analyser
 
 import brj.*
 import brj.runtime.Symbol
+import brj.types.Type
 
 import com.oracle.truffle.api.interop.TruffleObject
 import com.oracle.truffle.api.source.SourceSection
@@ -263,4 +264,13 @@ class ErrorValueExpr(
     override val loc: SourceSection? = null,
 ) : ValueExpr {
     override fun toString(): String = "<error: $message>"
+}
+
+class LangExpr(
+    val language: String,
+    val declaredType: Type,
+    val code: String,
+    override val loc: SourceSection? = null,
+) : ValueExpr {
+    override fun toString(): String = "(lang \"$language\" $declaredType)"
 }

--- a/language/src/main/kotlin/brj/effects/EffectChecker.kt
+++ b/language/src/main/kotlin/brj/effects/EffectChecker.kt
@@ -45,7 +45,7 @@ fun ValueExpr.inferEffects(): Set<GlobalVar> = when (this) {
     is StringExpr, is BoolExpr, is NilExpr,
     is LocalVarExpr, is CapturedVarExpr, is GlobalVarExpr,
     is TruffleObjectExpr, is HostStaticMethodExpr, is HostConstructorExpr,
-    is QuoteExpr, is ErrorValueExpr -> emptySet()
+    is QuoteExpr, is ErrorValueExpr, is LangExpr -> emptySet()
 }
 
 /**
@@ -81,5 +81,5 @@ fun ValueExpr.collectEffectfulCallees(): Set<GlobalVar> = when (this) {
     is StringExpr, is BoolExpr, is NilExpr,
     is LocalVarExpr, is CapturedVarExpr, is GlobalVarExpr,
     is TruffleObjectExpr, is HostStaticMethodExpr, is HostConstructorExpr,
-    is QuoteExpr, is EffectVarExpr, is ErrorValueExpr -> emptySet()
+    is QuoteExpr, is EffectVarExpr, is ErrorValueExpr, is LangExpr -> emptySet()
 }

--- a/language/src/main/kotlin/brj/nodes/LangNode.kt
+++ b/language/src/main/kotlin/brj/nodes/LangNode.kt
@@ -1,0 +1,12 @@
+package brj.nodes
+
+import brj.BridjeNode
+import com.oracle.truffle.api.frame.VirtualFrame
+import com.oracle.truffle.api.source.SourceSection
+
+class LangNode(
+    private val value: Any?,
+    loc: SourceSection?,
+) : BridjeNode(loc) {
+    override fun execute(frame: VirtualFrame): Any? = value
+}

--- a/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
+++ b/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
@@ -62,7 +62,7 @@ class ParseRootNode(
 
     @TruffleBoundary
     private fun evalExpr(expr: ValueExpr, slotCount: Int): Any? {
-        val emitter = Emitter(lang)
+        val emitter = Emitter(lang, BridjeContext.get(this))
         emitter.nextSlot = slotCount
         val node = emitter.emitExpr(expr)
         val frameDescriptor = buildFrameDescriptor(emitter.nextSlot)
@@ -81,7 +81,7 @@ class ParseRootNode(
         // The inner fn captures the fx map and pre-applied callees.
 
         val fxSlot = 0
-        val emitter = Emitter(lang)
+        val emitter = Emitter(lang, BridjeContext.get(this))
 
         // Find effectful callees in the body to pre-apply.
         val callees = fnExpr.bodyExpr.collectEffectfulCallees().toList()

--- a/language/src/main/kotlin/brj/types/Typing.kt
+++ b/language/src/main/kotlin/brj/types/Typing.kt
@@ -291,4 +291,5 @@ internal fun ValueExpr.typing(): Typing =
         is LoopExpr -> typing()
         is RecurExpr -> typing()
         is ErrorValueExpr -> Typing(freshType())
+        is LangExpr -> Typing(declaredType)
     }

--- a/language/src/test/kotlin/brj/LangTest.kt
+++ b/language/src/test/kotlin/brj/LangTest.kt
@@ -1,0 +1,91 @@
+package brj
+
+import org.graalvm.polyglot.PolyglotException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class LangTest {
+
+    @Test
+    fun `lang value form evaluates JS expression`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            lang: "js" Int
+              "40 + 2"
+        """.trimIndent())
+        assertEquals(42L, result.asLong())
+    }
+
+    @Test
+    fun `lang fn form produces callable`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              def: add
+                lang: "js" Fn([Int Int] Int)
+                  "(a, b) => a + b"
+              add(2, 3)
+        """.trimIndent())
+        assertEquals(5L, result.asLong())
+    }
+
+    @Test
+    fun `lang fn returning a string`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              def: greet
+                lang: "js" Fn([Str] Str)
+                  "(who) => 'hello, ' + who"
+              greet("world")
+        """.trimIndent())
+        assertTrue(result.isString, "Expected string, got $result")
+        assertEquals("hello, world", result.asString())
+    }
+
+    @Test
+    fun `lang float value`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            lang: "js" Double
+              "Math.PI"
+        """.trimIndent())
+        assertEquals(Math.PI, result.asDouble(), 1e-10)
+    }
+
+    @Test
+    fun `lang without code string errors at analyse time`() = withContext { ctx ->
+        val ex = assertThrows(PolyglotException::class.java) {
+            ctx.evalBridje("""
+                lang: "js" Int
+            """.trimIndent())
+        }
+        assertTrue(
+            ex.message?.contains("lang requires a code string") == true,
+            "Expected 'lang requires a code string', got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `lang without language literal errors at analyse time`() = withContext { ctx ->
+        val ex = assertThrows(PolyglotException::class.java) {
+            ctx.evalBridje("""
+                lang: js Int "42"
+            """.trimIndent())
+        }
+        assertTrue(
+            ex.message?.contains("lang requires a language name") == true,
+            "Expected 'lang requires a language name', got: ${ex.message}"
+        )
+    }
+
+    @Test
+    fun `lang with unavailable language errors at analyse time`() = withContext { ctx ->
+        val ex = assertThrows(PolyglotException::class.java) {
+            ctx.evalBridje("""
+                lang: "fortran77" Int
+                  "42"
+            """.trimIndent())
+        }
+        assertTrue(
+            ex.message?.contains("Language 'fortran77' is not available") == true,
+            "Expected 'Language not available' error, got: ${ex.message}"
+        )
+    }
+}

--- a/notes/SYNTAX.md
+++ b/notes/SYNTAX.md
@@ -80,6 +80,11 @@ The rule: `symbol:` opens a block.
 The block contains everything on the same line after the colon, plus any indented lines below.
 Nested colon blocks nest naturally via indentation.
 
+**The colon *is* the opening paren.**
+`foo: a b c` is exactly `(foo a b c)` — pick one or the other, never both.
+Writing `(foo: a b c)` double-wraps, producing `((foo a b c))`, and is almost never what you want.
+When a special form needs to appear mid-expression (e.g. as the callee in an immediate call), drop the colon and use the bare list form: `(fn [x] x)(7)`, `(lang "js" Int "42")`.
+
 ```bridje
 // Bridje:
 if: gt(a, b)


### PR DESCRIPTION
Resolves #104.

Bridje was sitting on GraalVM with no way to reach the other Truffle languages next to it.
This adds a `lang:` form that lets a Bridje global be implemented in JS / Ruby / Python / whatever else is on the classpath:

```
def: add
  lang: "js" Fn([Int Int] Int)
    "(a, b) => a + b"
```

See #104 for the motivation — this description focuses on how the implementation landed.

## Value position, not a new top-level form

The initial design proposed `lang:` as a top-level form parallel to `def:` / `decl:`.
Ended up value-position instead, simpler: one parser path, and `lang:` composes anonymously anywhere a value is expected.
`def: foo (lang "js" Fn([Int Int] Int) "(a,b) => a+b")` mirrors the shape `fn:` already uses — no special-casing.

Dropping the name from the `lang:` form itself followed naturally.
The original signature was `foo(Int, Int) Int` with a name baked in; now it's just the declared type (`Fn([Int Int] Int)` for callables, or any base type for values), because the name comes from the enclosing `def:` — or there is none.

## No runtime coercion

Host interop (`HostStaticMethodInvokeNode`) already returns the raw polyglot `Value` and trusts Bridje's `InteropLibrary`-backed type machinery to unbox at use sites.
`lang:` matches that: the declared type is a type-system assertion, not a runtime conversion.
Consistency is part of the win; the bigger one is that the compiler stays language-agnostic.
The user writes the callable literal themselves (`(a,b) => a+b`, `proc { ... }`), so the emitter never needs to know any language's syntax.

## One node, not two

An earlier sketch had separate `LangFnNode` / `LangInvokeRootNode` / `LangValueNode`, because function form needs the callable wrapped in something Bridje can invoke and value form doesn't.
Once coercion was dropped, both cases collapse.
Polyglot values are already `isExecutable` when callable, and Bridje's `InvokeNode` already uses `InteropLibrary.execute` on anything executable — so the function form works for free.
The runtime file is ten lines.

## Parse once, at emit time

`Emitter.emitLang` calls `parsePublic(…).call()` and stashes the result in `LangNode`.
We're already inside a Truffle context when the Emitter runs (called from `ParseRootNode`), so no lazy-init is needed.
An earlier pass had a `@CompilationFinal` + `isSet` lazy cache that the user correctly flagged as over-engineering — dropped.

One consequence worth knowing: source-level side effects in the polyglot code (`"console.log('hi'); 42"`) fire once at definition time, not per invocation.
That's the intended "eval once" semantics.

## Language availability validated at analyse time

`analyseLang` checks `truffleEnv.publicLanguages.keys` and returns an analyser error if the id isn't known.
Users see `Language 'ruby' is not available. Available: [js, bridje]` pointing at the `lang:` form, instead of an opaque `PolyglotException` from deep in the emitter later.

## `BridjeContext` through the `Emitter` constructor (refactor, behaviour-preserving)

Post code-review fix.
The first cut reached for the `BridjeContext.current()` static accessor because `Emitter` isn't a `Node` and can't call `BridjeContext.get(this)`.
The reviewer pointed out that the rest of the codebase threads context through `Node` references, and the static fallback would silently break if `ContextPolicy` ever stopped being `EXCLUSIVE`.
`Emitter` now takes `ctx: BridjeContext` alongside `language: BridjeLanguage`; `ParseRootNode` passes `BridjeContext.get(this)` at the two construction sites.

## Colon-paren gotcha

Hit this while writing an inline-call test: `(lang: "js" Fn([Int] Int) "(x) => x * x")(7)` type-errored with "arity 1 vs 0".
Because `foo: a b c` desugars to `(foo a b c)`, the outer parens double-wrap to `((lang …))`, and the call site sees the outer paren as a zero-arg call to whatever that construct is.
Added a short note to `notes/SYNTAX.md` right where colon blocks are introduced — applies to every special form, not just `lang:`.

## Out of scope for v1

- Object / record marshalling between Bridje and polyglot values.
- Effect-system integration for polyglot side effects (polyglot calls currently count as pure).
- `decl:`-vs-`def:` type enforcement.
Bridje doesn't do this for any form today, so no new check was added here either.

## Test plan

- [x] `./gradlew :language:test --tests "brj.LangTest*"` — 6 new tests: value form, function form, string return, float value, analyser errors for missing code / missing language literal / unavailable language id.
- [x] `./gradlew :language:test` — 575 tests pass, 0 failures, no regressions.
- [x] Uses `testRuntimeOnly(libs.graal.js)` (`org.graalvm.js:js-community:25.0.2`) so `"js"` is actually available at test time.
- [ ] REPL still needs manual verification on the `poly` branch — not wired for polyglot access out of the box.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>