### PR TITLE
BridjeSet runtime class (part of #89)

### DIFF
--- a/language/src/main/brj/brj/core.brj
+++ b/language/src/main/brj/brj/core.brj
@@ -1,6 +1,8 @@
 ns: brj.core
   import:
-    brj.runtime: as(BridjeVector, Vec)
+    brj.runtime:
+      as(BridjeVector, Vec)
+      as(BridjeSet, Set)
   require:
     brj: as(rdr, f)
 
@@ -12,6 +14,14 @@ decl: [a] Vec/cons(a, [a]) [a]
 decl: [a] Vec/isEmpty([a]) Bool
 decl: [a] Vec/concat([a], [a]) [a]
 
+decl: [a] Set/count(#{a}) Int
+decl: [a] Set/isEmpty(#{a}) Bool
+decl: [a] Set/contains(#{a}, a) Bool
+decl: [a] Set/conj(a, #{a}) #{a}
+decl: [a] Set/disj(a, #{a}) #{a}
+decl: [a] Set/union(#{a}, #{a}) #{a}
+decl: [a] Set/fromVec([a]) #{a}
+
 def: count(xs) Vec/count(xs)
 def: first(xs) Vec/first(xs)
 def: first-or-null(xs) Vec/firstOrNull(xs)
@@ -19,6 +29,14 @@ def: rest(xs) Vec/rest(xs)
 def: cons(x, xs) Vec/cons(x, xs)
 def: empty?(xs) Vec/isEmpty(xs)
 def: concat(xs, ys) Vec/concat(xs, ys)
+
+def: set(xs) Set/fromVec(xs)
+def: set-count(s) Set/count(s)
+def: set-empty?(s) Set/isEmpty(s)
+def: contains?(s, x) Set/contains(s, x)
+def: conj(x, s) Set/conj(x, s)
+def: disj(x, s) Set/disj(x, s)
+def: union(a, b) Set/union(a, b)
 
 decl: [a, b] reduce(Iterable(a), b, Fn([b, a] b)) b
 def: reduce(xs, init, f)

--- a/language/src/main/kotlin/brj/runtime/BridjeSet.kt
+++ b/language/src/main/kotlin/brj/runtime/BridjeSet.kt
@@ -1,0 +1,95 @@
+package brj.runtime
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary
+import com.oracle.truffle.api.interop.InteropLibrary
+import com.oracle.truffle.api.interop.StopIterationException
+import com.oracle.truffle.api.interop.TruffleObject
+import com.oracle.truffle.api.library.ExportLibrary
+import com.oracle.truffle.api.library.ExportMessage
+
+@ExportLibrary(InteropLibrary::class)
+class BridjeSet(val els: Set<Any>, override val meta: BridjeRecord = BridjeRecord.EMPTY) : TruffleObject, Meta<BridjeSet> {
+
+    companion object {
+        val EMPTY: BridjeSet = BridjeSet(emptySet())
+
+        @JvmStatic
+        fun count(set: BridjeSet): Long = set.els.size.toLong()
+
+        @JvmStatic
+        fun isEmpty(set: BridjeSet): Boolean = set.els.isEmpty()
+
+        @JvmStatic
+        fun contains(set: BridjeSet, el: Any): Boolean = set.els.contains(el)
+
+        @JvmStatic
+        fun conj(el: Any, set: BridjeSet): BridjeSet {
+            if (el in set.els) return set
+            val next = LinkedHashSet<Any>(set.els.size + 1)
+            next.addAll(set.els)
+            next.add(el)
+            return BridjeSet(next)
+        }
+
+        @JvmStatic
+        fun disj(el: Any, set: BridjeSet): BridjeSet {
+            if (el !in set.els) return set
+            val next = LinkedHashSet<Any>(set.els.size)
+            for (x in set.els) if (x != el) next.add(x)
+            return BridjeSet(next)
+        }
+
+        @JvmStatic
+        fun union(a: BridjeSet, b: BridjeSet): BridjeSet {
+            if (a.els.isEmpty()) return b
+            if (b.els.isEmpty()) return a
+            val next = LinkedHashSet<Any>(a.els.size + b.els.size)
+            next.addAll(a.els)
+            next.addAll(b.els)
+            return BridjeSet(next)
+        }
+
+        @JvmStatic
+        fun fromVec(vec: BridjeVector): BridjeSet {
+            if (vec.els.isEmpty()) return EMPTY
+            val next = LinkedHashSet<Any>(vec.els.size)
+            next.addAll(vec.els)
+            return BridjeSet(next)
+        }
+    }
+
+    override fun withMeta(newMeta: BridjeRecord?): BridjeSet = BridjeSet(els, newMeta ?: BridjeRecord.EMPTY)
+
+    @ExportMessage
+    fun hasIterator() = true
+
+    @ExportMessage
+    fun getIterator(): Any = BridjeSetIterator(els.iterator())
+
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage
+    @TruffleBoundary
+    fun toDisplayString(allowSideEffects: Boolean): String {
+        val interop = InteropLibrary.getUncached()
+        return "#{${els.joinToString(" ") { interop.toDisplayString(it) as String }}}"
+    }
+}
+
+@ExportLibrary(InteropLibrary::class)
+class BridjeSetIterator(private val iter: Iterator<Any>) : TruffleObject {
+
+    @ExportMessage
+    fun isIterator() = true
+
+    @ExportMessage
+    @TruffleBoundary
+    fun hasIteratorNextElement(): Boolean = iter.hasNext()
+
+    @ExportMessage
+    @TruffleBoundary
+    @Throws(StopIterationException::class)
+    fun getIteratorNextElement(): Any {
+        if (!iter.hasNext()) throw StopIterationException.create()
+        return iter.next()
+    }
+}

--- a/language/src/main/kotlin/brj/types/Constraint.kt
+++ b/language/src/main/kotlin/brj/types/Constraint.kt
@@ -127,6 +127,10 @@ internal fun Collection<Constraint>.resolve(): Subst {
                     lower.base is VectorType && upper.base is IterableType ->
                         queue.add(lower.base.el subOf upper.base.el)
 
+                    // SetType <: IterableType — direct, covariant
+                    lower.base is SetType && upper.base is IterableType ->
+                        queue.add(lower.base.el subOf upper.base.el)
+
                     // HostType <: protocol type — rewrite to HostType <: HostType(java interface)
                     lower.base is HostType && upper.base is IterableType ->
                         queue.add(lower subOf HostType(J_L_ITERABLE.name, listOf(upper.base.el), listOf(Variance.OUT)).notNull())

--- a/language/src/main/kotlin/brj/types/Subst.kt
+++ b/language/src/main/kotlin/brj/types/Subst.kt
@@ -60,6 +60,9 @@ internal infix fun BaseType.join(other: BaseType): BaseType = when {
     // Cross-kind: VectorType ↔ IterableType — join picks the supertype (protocol)
     this is VectorType && other is IterableType -> other
     other is VectorType && this is IterableType -> this
+    // Cross-kind: SetType ↔ IterableType — join picks the supertype (protocol)
+    this is SetType && other is IterableType -> other
+    other is SetType && this is IterableType -> this
     this is HostType && other is HostType && className == other.className && args.size == other.args.size && args.isNotEmpty() ->
         HostType(className, joinArgs(variances, args, other.args), variances)
     // Join of different HostTypes — pick the supertype (less specific)
@@ -96,6 +99,9 @@ internal infix fun BaseType.meet(other: BaseType): BaseType = when {
     // Cross-kind: VectorType ↔ IterableType — meet picks the subtype (VectorType)
     this is VectorType && other is IterableType -> this
     other is VectorType && this is IterableType -> other
+    // Cross-kind: SetType ↔ IterableType — meet picks the subtype (SetType)
+    this is SetType && other is IterableType -> this
+    other is SetType && this is IterableType -> other
     // Cross-kind: HostType ↔ IterableType — meet picks the HostType (subtype)
     this is HostType && other is IterableType -> this
     other is HostType && this is IterableType -> other

--- a/language/src/test/kotlin/brj/SetTest.kt
+++ b/language/src/test/kotlin/brj/SetTest.kt
@@ -1,0 +1,144 @@
+package brj
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class SetTest {
+    @Test
+    fun `empty set from empty vector`() = withContext { ctx ->
+        val result = ctx.evalBridje("set([])")
+        assertTrue(result.hasIterator())
+        assertFalse(result.iterator.hasIteratorNextElement())
+    }
+
+    @Test
+    fun `set from vector has iterator`() = withContext { ctx ->
+        val result = ctx.evalBridje("set([1, 2, 3])")
+        assertTrue(result.hasIterator())
+    }
+
+    @Test
+    fun `set count`() = withContext { ctx ->
+        assertEquals(3L, ctx.evalBridje("set-count(set([1, 2, 3]))").asLong())
+        assertEquals(0L, ctx.evalBridje("set-count(set([]))").asLong())
+    }
+
+    @Test
+    fun `set deduplicates`() = withContext { ctx ->
+        assertEquals(2L, ctx.evalBridje("set-count(set([1, 2, 1, 2, 1]))").asLong())
+    }
+
+    @Test
+    fun `set-empty on empty set is true`() = withContext { ctx ->
+        assertTrue(ctx.evalBridje("set-empty?(set([]))").asBoolean())
+    }
+
+    @Test
+    fun `set-empty on non-empty set is false`() = withContext { ctx ->
+        assertFalse(ctx.evalBridje("set-empty?(set([1]))").asBoolean())
+    }
+
+    @Test
+    fun `contains on member`() = withContext { ctx ->
+        assertTrue(ctx.evalBridje("contains?(set([1, 2, 3]), 2)").asBoolean())
+    }
+
+    @Test
+    fun `contains on non-member`() = withContext { ctx ->
+        assertFalse(ctx.evalBridje("contains?(set([1, 2, 3]), 42)").asBoolean())
+    }
+
+    @Test
+    fun `conj adds element`() = withContext { ctx ->
+        val result = ctx.evalBridje("set-count(conj(4, set([1, 2, 3])))")
+        assertEquals(4L, result.asLong())
+    }
+
+    @Test
+    fun `conj existing element is no-op`() = withContext { ctx ->
+        val result = ctx.evalBridje("set-count(conj(2, set([1, 2, 3])))")
+        assertEquals(3L, result.asLong())
+    }
+
+    @Test
+    fun `conj result contains new element`() = withContext { ctx ->
+        assertTrue(ctx.evalBridje("contains?(conj(42, set([1, 2, 3])), 42)").asBoolean())
+    }
+
+    @Test
+    fun `disj removes element`() = withContext { ctx ->
+        val result = ctx.evalBridje("set-count(disj(2, set([1, 2, 3])))")
+        assertEquals(2L, result.asLong())
+    }
+
+    @Test
+    fun `disj missing element is no-op`() = withContext { ctx ->
+        val result = ctx.evalBridje("set-count(disj(42, set([1, 2, 3])))")
+        assertEquals(3L, result.asLong())
+    }
+
+    @Test
+    fun `disj result does not contain removed element`() = withContext { ctx ->
+        assertFalse(ctx.evalBridje("contains?(disj(2, set([1, 2, 3])), 2)").asBoolean())
+    }
+
+    @Test
+    fun `union combines sets`() = withContext { ctx ->
+        val result = ctx.evalBridje("set-count(union(set([1, 2]), set([2, 3, 4])))")
+        assertEquals(4L, result.asLong())
+    }
+
+    @Test
+    fun `union with empty`() = withContext { ctx ->
+        assertEquals(3L, ctx.evalBridje("set-count(union(set([1, 2, 3]), set([])))").asLong())
+        assertEquals(3L, ctx.evalBridje("set-count(union(set([]), set([1, 2, 3])))").asLong())
+    }
+
+    @Test
+    fun `set is immutable - conj returns new set`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            let: [s set([1, 2, 3])
+                  t conj(4, s)]
+              sub(set-count(t), set-count(s))
+        """.trimIndent())
+        assertEquals(1L, result.asLong())
+    }
+
+    @Test
+    fun `set iteration yields all elements`() = withContext { ctx ->
+        val result = ctx.evalBridje("set([10, 20, 30])")
+        assertTrue(result.hasIterator())
+        val iter = result.iterator
+        val seen = mutableSetOf<Long>()
+        while (iter.hasIteratorNextElement()) {
+            seen.add(iter.iteratorNextElement.asLong())
+        }
+        assertEquals(setOf(10L, 20L, 30L), seen)
+    }
+
+    @Test
+    fun `set display string`() = withContext { ctx ->
+        val result = ctx.evalBridje("set([1, 2, 3])")
+        assertEquals("#{1 2 3}", result.toString())
+    }
+
+    @Test
+    fun `empty set display string`() = withContext { ctx ->
+        val result = ctx.evalBridje("set([])")
+        assertEquals("#{}", result.toString())
+    }
+
+    @Test
+    fun `set flows into reduce via Iterable subtyping`() = withContext { ctx ->
+        // Sums the elements of a set by passing it where an Iterable is expected.
+        // Proves SetType <: IterableType at the type level.
+        val result = ctx.evalBridje("reduce(set([1, 2, 3]), 0, add)")
+        assertEquals(6L, result.asLong())
+    }
+
+    @Test
+    fun `set flows into mapv via Iterable subtyping`() = withContext { ctx ->
+        val result = ctx.evalBridje("count(mapv(set([1, 2, 3]), fn: inc(x) add(x, 1)))")
+        assertEquals(3L, result.asLong())
+    }
+}


### PR DESCRIPTION
Fills in the `brj.runtime.BridjeSet` runtime that `SetType` was already referring to.
Without this, any attempt to construct a set-typed value had nothing to live in.

## What's in

- `BridjeSet` backed by an insertion-ordered `LinkedHashSet`, modelled on `BridjeVector` for `Meta` / `withMeta` / `toDisplayString` and companion `@JvmStatic` ops.
- Truffle iterator protocol rather than array-element access, since sets are logically unordered even if the backing store isn't.
- Wired into `brj.core` in the vector style: host import, `Set/…` decls, thin Bridje-level wrappers (`set`, `set-count`, `set-empty?`, `contains?`, `conj`, `disj`, `union`).
- `SetType <: IterableType` subtyping, so sets flow into `reduce` / `mapv` / `filterv` etc. Mirrors the existing `VectorType <: IterableType` rule.

## Out of scope

- `#{…}` set literal syntax — the emitter still has `TODO()` there, deferred deliberately.
- Map — the other half of #89, still outstanding.

## Tests

22 tests in `SetTest`. Full `:language:test` green — 602/602.