### PR TITLE
with() record update (resolves #88)

### DIFF
--- a/language/src/main/kotlin/brj/Emitter.kt
+++ b/language/src/main/kotlin/brj/Emitter.kt
@@ -141,6 +141,12 @@ class Emitter(private val language: BridjeLanguage, private val ctx: BridjeConte
         is CaseExpr -> emitCase(expr, fxSource, preApplied)
         is TryCatchExpr -> emitTryCatch(expr, fxSource, preApplied)
         is RecordSetExpr -> RecordSetNode(expr.key, emitExpr(expr.recordExpr, fxSource, preApplied), emitExpr(expr.valueExpr, fxSource, preApplied), expr.loc)
+        is RecordUpdateExpr -> RecordUpdateNode(
+            expr.fields.map { it.first }.toTypedArray(),
+            emitExpr(expr.recordExpr, fxSource, preApplied),
+            expr.fields.map { emitExpr(it.second, fxSource, preApplied) }.toTypedArray(),
+            expr.loc
+        )
         is EffectVarExpr -> {
             if (fxSource != null) ReadFxMapEntryNode(fxSource.create(), expr.effectVar, expr.loc)
             else GlobalVarNode(expr.effectVar, expr.loc)

--- a/language/src/main/kotlin/brj/analyser/Analyser.kt
+++ b/language/src/main/kotlin/brj/analyser/Analyser.kt
@@ -258,6 +258,7 @@ data class Analyser(
                 "quote" -> analyseQuote(form)
                 "set!" -> analyseSet(form)
                 "withFx" -> analyseWithFx(form)
+                "with" -> analyseWith(form)
                 "loop" -> analyseLoop(form)
                 "recur" -> analyseRecur(form)
                 "def" -> errorExpr("def not allowed in value position", form.loc)
@@ -786,6 +787,51 @@ data class Analyser(
         val valueExpr = analyseValueExpr(els[3])
 
         return RecordSetExpr(recordExpr, keyValue.name, valueExpr, form.loc)
+    }
+
+    private fun resolveDotSymbolKey(form: DotSymbolForm): GlobalVar? =
+        nsEnv.key(form.sym) ?: ctx.brjCore.key(form.sym)
+
+    private fun resolveQualifiedDotSymbolKey(form: QDotSymbolForm): GlobalVar? {
+        ctx.namespaces[form.ns.name]?.key(form.member)?.let { return it }
+        nsEnv.requires[form.ns.name]?.key(form.member)?.let { return it }
+        return null
+    }
+
+    private fun analyseWith(form: ListForm): ValueExpr {
+        val els = form.els
+        if (els.size < 2)
+            return errorExpr("with requires a record and at least one field/value pair", form.loc)
+
+        val updates = els.drop(2)
+        if (updates.size % 2 != 0)
+            return errorExpr("with requires an even number of field/value forms after the record", form.loc)
+
+        if (updates.isEmpty())
+            return errorExpr("with requires a record and at least one field/value pair", form.loc)
+
+        val recordExpr = analyseValueExpr(els[1])
+
+        val fields = mutableListOf<Pair<String, ValueExpr>>()
+        for (i in updates.indices step 2) {
+            val fieldForm = updates[i]
+            val keyVar = when (fieldForm) {
+                is DotSymbolForm ->
+                    resolveDotSymbolKey(fieldForm)
+                        ?: return errorExpr("Unknown field: .${fieldForm.sym.name}", fieldForm.loc)
+                is QDotSymbolForm ->
+                    resolveQualifiedDotSymbolKey(fieldForm)
+                        ?: return errorExpr("Unknown field: $fieldForm", fieldForm.loc)
+                else ->
+                    return errorExpr("with field selector must be a dot-symbol (.field)", fieldForm.loc)
+            }
+            val keyValue = keyVar.value
+            if (keyValue !is BridjeKey) return errorExpr("$fieldForm is not a key", fieldForm.loc)
+            val valueExpr = analyseValueExpr(updates[i + 1])
+            fields.add(keyValue.name to valueExpr)
+        }
+
+        return RecordUpdateExpr(recordExpr, fields, form.loc)
     }
 
     private fun analyseLet(form: ListForm): ValueExpr {

--- a/language/src/main/kotlin/brj/analyser/ValueExpr.kt
+++ b/language/src/main/kotlin/brj/analyser/ValueExpr.kt
@@ -208,6 +208,17 @@ class RecordSetExpr(
     override fun toString(): String = "(set! $recordExpr :$key $valueExpr)"
 }
 
+class RecordUpdateExpr(
+    val recordExpr: ValueExpr,
+    val fields: List<Pair<String, ValueExpr>>,
+    override val loc: SourceSection? = null
+) : ValueExpr {
+    override fun toString(): String {
+        val fieldsStr = fields.joinToString(" ") { (k, v) -> ".$k $v" }
+        return "(with $recordExpr $fieldsStr)"
+    }
+}
+
 class EffectVarExpr(
     val name: Symbol,
     val effectVar: GlobalVar,

--- a/language/src/main/kotlin/brj/effects/EffectChecker.kt
+++ b/language/src/main/kotlin/brj/effects/EffectChecker.kt
@@ -37,6 +37,7 @@ fun ValueExpr.inferEffects(): Set<GlobalVar> = when (this) {
     }
     is RecordExpr -> fields.flatMap { it.second.inferEffects() }.toSet()
     is RecordSetExpr -> recordExpr.inferEffects() + valueExpr.inferEffects()
+    is RecordUpdateExpr -> recordExpr.inferEffects() + fields.flatMap { it.second.inferEffects() }.toSet()
     is VectorExpr -> els.flatMap { it.inferEffects() }.toSet()
     is SetExpr -> els.flatMap { it.inferEffects() }.toSet()
     is LoopExpr -> bindings.flatMap { it.second.inferEffects() }.toSet() + bodyExpr.inferEffects()
@@ -73,6 +74,7 @@ fun ValueExpr.collectEffectfulCallees(): Set<GlobalVar> = when (this) {
         (finallyExpr?.collectEffectfulCallees() ?: emptySet())
     is RecordExpr -> fields.flatMap { it.second.collectEffectfulCallees() }.toSet()
     is RecordSetExpr -> recordExpr.collectEffectfulCallees() + valueExpr.collectEffectfulCallees()
+    is RecordUpdateExpr -> recordExpr.collectEffectfulCallees() + fields.flatMap { it.second.collectEffectfulCallees() }.toSet()
     is VectorExpr -> els.flatMap { it.collectEffectfulCallees() }.toSet()
     is SetExpr -> els.flatMap { it.collectEffectfulCallees() }.toSet()
     is LoopExpr -> bindings.flatMap { it.second.collectEffectfulCallees() }.toSet() + bodyExpr.collectEffectfulCallees()

--- a/language/src/main/kotlin/brj/nodes/RecordUpdateNode.kt
+++ b/language/src/main/kotlin/brj/nodes/RecordUpdateNode.kt
@@ -1,0 +1,25 @@
+package brj.nodes
+
+import brj.BridjeNode
+import brj.runtime.BridjeRecord
+import com.oracle.truffle.api.frame.VirtualFrame
+import com.oracle.truffle.api.nodes.ExplodeLoop
+import com.oracle.truffle.api.source.SourceSection
+
+class RecordUpdateNode(
+    private val keys: Array<String>,
+    @field:Child private var recordNode: BridjeNode,
+    @field:Children private val valueNodes: Array<BridjeNode>,
+    loc: SourceSection? = null
+) : BridjeNode(loc) {
+
+    @ExplodeLoop
+    override fun execute(frame: VirtualFrame): Any {
+        var record = recordNode.execute(frame) as BridjeRecord
+        for (i in keys.indices) {
+            val value = valueNodes[i].execute(frame)
+            record = record.put(keys[i], value)
+        }
+        return record
+    }
+}

--- a/language/src/main/kotlin/brj/types/Typing.kt
+++ b/language/src/main/kotlin/brj/types/Typing.kt
@@ -149,6 +149,17 @@ internal fun RecordSetExpr.typing(): Typing {
     )
 }
 
+internal fun RecordUpdateExpr.typing(): Typing {
+    val recordTyping = recordExpr.typing()
+    val fieldTypings = fields.map { (_, v) -> v.typing() }
+
+    return Typing.build(
+        RecordType.notNull(),
+        childTypings = listOf(recordTyping) + fieldTypings,
+        constraints = listOf(recordTyping.type subOf RecordType.notNull()),
+    )
+}
+
 internal fun SetExpr.typing(): Typing {
     val elemTypings = els.map { it.typing() }
     val elemType = freshType()
@@ -278,6 +289,7 @@ internal fun ValueExpr.typing(): Typing =
         is HostStaticMethodExpr -> Typing(freshType())
         is HostConstructorExpr -> Typing(freshType())
         is RecordSetExpr -> typing()
+        is RecordUpdateExpr -> typing()
         is EffectVarExpr -> Typing(effectVar.type?.instantiate() ?: freshType())
         is WithFxExpr -> {
             val bindingTypings = bindings.map { (_, expr) -> expr.typing() }

--- a/language/src/test/kotlin/brj/RecordUpdateTest.kt
+++ b/language/src/test/kotlin/brj/RecordUpdateTest.kt
@@ -1,0 +1,166 @@
+package brj
+
+import org.graalvm.polyglot.PolyglotException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class RecordUpdateTest {
+
+    @Test
+    fun `with updates a single field`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              decl: :foo Str
+              let: [r {:foo 1}]
+                with(r, .foo 99)
+        """.trimIndent())
+        assertEquals(99L, result.getMember("foo").asLong())
+    }
+
+    @Test
+    fun `with returns a new record without mutating the original`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              decl: :foo Str
+              let: [r {:foo 1}
+                    updated with(r, .foo 99)]
+                [(:foo r), (:foo updated)]
+        """.trimIndent())
+        assertEquals(1L, result.getArrayElement(0).asLong())
+        assertEquals(99L, result.getArrayElement(1).asLong())
+    }
+
+    @Test
+    fun `with updates multiple fields`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              decl: {:a Str, :b Str, :c Str}
+              let: [r {:a 1, :b 2, :c 3}]
+                with(r, .a 10, .b 20)
+        """.trimIndent())
+        assertEquals(10L, result.getMember("a").asLong())
+        assertEquals(20L, result.getMember("b").asLong())
+        assertEquals(3L, result.getMember("c").asLong())
+    }
+
+    @Test
+    fun `with preserves unupdated fields`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              decl: {:a Str, :b Str}
+              with({:a 1, :b 2}, .a 99)
+        """.trimIndent())
+        assertEquals(99L, result.getMember("a").asLong())
+        assertEquals(2L, result.getMember("b").asLong())
+    }
+
+    @Test
+    fun `with via list syntax`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              decl: :foo Str
+              (with {:foo 1} .foo 99)
+        """.trimIndent())
+        assertEquals(99L, result.getMember("foo").asLong())
+    }
+
+    @Test
+    fun `with rejects unknown field`() = withContext { ctx ->
+        val ex = assertThrows(PolyglotException::class.java) {
+            ctx.evalBridje("""
+                do:
+                  decl: :foo Str
+                  with({:foo 1}, .bar 99)
+            """.trimIndent())
+        }
+        assertTrue(ex.message?.contains("Unknown field") == true,
+            "Expected unknown-field error, got: ${ex.message}")
+        assertTrue(ex.message?.contains("bar") == true,
+            "Expected error to mention the unknown field name, got: ${ex.message}")
+    }
+
+    @Test
+    fun `with rejects odd number of field forms`() = withContext { ctx ->
+        val ex = assertThrows(PolyglotException::class.java) {
+            ctx.evalBridje("""
+                do:
+                  decl: :foo Str
+                  with({:foo 1}, .foo)
+            """.trimIndent())
+        }
+        assertTrue(ex.message?.contains("even number of field") == true,
+            "Expected arity error, got: ${ex.message}")
+    }
+
+    @Test
+    fun `with rejects non-dot-symbol field selector`() = withContext { ctx ->
+        val ex = assertThrows(PolyglotException::class.java) {
+            ctx.evalBridje("""
+                do:
+                  decl: :foo Str
+                  with({:foo 1}, :foo 99)
+            """.trimIndent())
+        }
+        assertTrue(ex.message?.contains("dot-symbol") == true,
+            "Expected dot-symbol error, got: ${ex.message}")
+    }
+
+    @Test
+    fun `with requires a record and at least one field update`() = withContext { ctx ->
+        val ex = assertThrows(PolyglotException::class.java) {
+            ctx.evalBridje("""
+                do:
+                  decl: :foo Str
+                  with({:foo 1})
+            """.trimIndent())
+        }
+        assertTrue(ex.message?.contains("at least one field") == true,
+            "Expected arity error, got: ${ex.message}")
+    }
+
+    @Test
+    fun `with on qualified key`() = withContext { ctx ->
+        ctx.evalBridje("""
+            ns: my.keys
+            decl: :foo Str
+        """.trimIndent())
+
+        val ns = ctx.evalBridje("""
+            ns: consumer
+              require:
+                my:
+                  as(keys, k)
+            def: result
+              with({:k/foo 1}, k/.foo 99)
+        """.trimIndent())
+
+        assertEquals(99L, ns.getMember("result").getMember("foo").asLong())
+    }
+
+    @Test
+    fun `with composes cleanly`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              decl: {:x Int, :y Int, :z Int}
+              let: [r {:x 1, :y 2, :z 3}
+                    r2 with(r, .x 10)
+                    r3 with(r2, .y 20, .z 30)]
+                r3
+        """.trimIndent())
+        assertEquals(10L, result.getMember("x").asLong())
+        assertEquals(20L, result.getMember("y").asLong())
+        assertEquals(30L, result.getMember("z").asLong())
+    }
+
+    @Test
+    fun `with value expressions are evaluated`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            do:
+              decl: {:a Int, :b Int}
+              let: [r {:a 1, :b 2}]
+                with(r, .a add(10, 20), .b mul(3, 4))
+        """.trimIndent())
+        assertEquals(30L, result.getMember("a").asLong())
+        assertEquals(12L, result.getMember("b").asLong())
+    }
+}


### PR DESCRIPTION
Adds `with(record, .field1 val1, .field2 val2, ...)` — returns a new record with the specified fields updated.
Heavily needed in record-heavy state-transition code (e.g. `raft-clean.brj`, where every handler builds a new state with a handful of field updates).

Stacked on #109 (BridjeSet).

## Implementation

Special form, not macro.
A macro would need a value-level `assoc`/`put` primitive, because dot-symbol selectors (`.field`) don't have a runtime value representation — they carry a symbolic name, not an accessor function.
The special form lets the analyser reach each field form directly for existence checks, mirroring how the existing `set!` / `RecordSetExpr` is wired.

Touches the analyser, typing, effect-checker, emitter, and adds a new `RecordUpdateNode` that chains `BridjeRecord.put` calls.

## What `with` does check at compile time

- Selector must be a dot-symbol or qualified dot-symbol — any other form (including keywords) errors.
- Field name must resolve to a declared `BridjeKey` in the current ns, `brj.core`, or a required alias — unknown selectors error at analysis.
- Arity: record + at least one `.field value` pair; pairs must be even.
- Result type is `Record.notNull()`, matching `set!`.

## What it deliberately doesn't check — and why

Per-field value type-checking is not implementable in the current type system without a larger refactor.
Keys declared via `decl: :foo Str` register an accessor var of type `Fn([Record], fresh-type-var)` — the declared `Str` is discarded at `DefKeysExpr` construction.
The analyser has no way to look up a field's declared value type.

`RecordSetExpr` already has this same gap — its test `set! with qualified key` passes an `Int` into a `Str` field without error.
`with` ships at parity, not as a regression. A follow-up issue tracks fixing the underlying type-discard.

## Tests

12 tests in `RecordUpdateTest`. Full `:language:test` green.