### PR TITLE
Bytes virtual type and brj.fs read-bytes (resolves #99)

### DIFF
--- a/language/src/main/brj/brj/bytes.brj
+++ b/language/src/main/brj/brj/bytes.brj
@@ -1,0 +1,1 @@
+ns: brj.bytes

--- a/language/src/main/brj/brj/str.brj
+++ b/language/src/main/brj/brj/str.brj
@@ -1,0 +1,1 @@
+ns: brj.str

--- a/language/src/main/kotlin/brj/NsEnv.kt
+++ b/language/src/main/kotlin/brj/NsEnv.kt
@@ -3,6 +3,9 @@ package brj
 import brj.analyser.NsDecl
 import brj.builtins.Builtins
 import brj.builtins.AwaitNode
+import brj.builtins.BytesCountNode
+import brj.builtins.BytesFromStrNode
+import brj.builtins.BytesNthNode
 import brj.builtins.FileNode
 import brj.builtins.FormsFromFileNode
 import brj.builtins.FormsFromStringNode
@@ -12,9 +15,11 @@ import brj.builtins.FsIsFileNode
 import brj.builtins.FsListNode
 import brj.builtins.FsNameNode
 import brj.builtins.FsPathNode
+import brj.builtins.FsReadBytesNode
 import brj.builtins.FsReadStringNode
 import brj.builtins.FsResolveNode
 import brj.builtins.SpawnNode
+import brj.builtins.StrFromBytesNode
 import brj.runtime.Anomaly
 import brj.runtime.BridjeFunction
 import brj.runtime.BridjeRecord
@@ -23,8 +28,10 @@ import brj.runtime.Symbol
 import brj.runtime.SymbolMeta
 import brj.runtime.sym
 import brj.types.BoolType
+import brj.types.BytesType
 import brj.types.FnType
 import brj.types.FormType
+import brj.types.IntType
 import brj.types.RecordType
 import brj.types.StringType
 import brj.types.TagType
@@ -128,6 +135,7 @@ data class NsEnv(
             val fileTagType = TagType("brj.fs", "File").notNull()
             val str = StringType.notNull()
             val bool = BoolType.notNull()
+            val bytes = BytesType.notNull()
 
             fun gv(name: Symbol, node: RootNode, params: List<Type>, ret: Type): Pair<Symbol, GlobalVar> =
                 name to GlobalVar(fsNs, name, BridjeFunction(node.callTarget),
@@ -140,11 +148,43 @@ data class NsEnv(
                 gv("isFile?".sym, FsIsFileNode(language), listOf(fileTagType), bool),
                 gv("isDir?".sym, FsIsDirNode(language), listOf(fileTagType), bool),
                 gv("readString".sym, FsReadStringNode(language), listOf(fileTagType), str),
+                gv("<-bytes".sym, FsReadBytesNode(language), listOf(fileTagType), bytes),
                 gv("list".sym, FsListNode(language), listOf(fileTagType), VectorType(fileTagType).notNull()),
                 gv("resolve".sym, FsResolveNode(language), listOf(fileTagType, str), fileTagType),
                 gv("name".sym, FsNameNode(language), listOf(fileTagType), str),
                 gv("path".sym, FsPathNode(language), listOf(fileTagType), str),
                 "File".sym to GlobalVar(fsNs, "File".sym, FileMeta, type = fileCtorType),
+            ))
+        }
+
+        fun withBytesBuiltins(language: BridjeLanguage): NsEnv {
+            val bytesNs = "brj.bytes".sym
+            val bytes = BytesType.notNull()
+            val str = StringType.notNull()
+            val int = IntType.notNull()
+
+            fun gv(name: Symbol, node: RootNode, params: List<Type>, ret: Type): Pair<Symbol, GlobalVar> =
+                name to GlobalVar(bytesNs, name, BridjeFunction(node.callTarget),
+                    type = FnType(params, ret).notNull())
+
+            return NsEnv(vars = mapOf(
+                gv("count".sym, BytesCountNode(language), listOf(bytes), int),
+                gv("nth".sym, BytesNthNode(language), listOf(bytes, int), int),
+                gv("<-str".sym, BytesFromStrNode(language), listOf(str), bytes),
+            ))
+        }
+
+        fun withStrBuiltins(language: BridjeLanguage): NsEnv {
+            val strNs = "brj.str".sym
+            val bytes = BytesType.notNull()
+            val str = StringType.notNull()
+
+            fun gv(name: Symbol, node: RootNode, params: List<Type>, ret: Type): Pair<Symbol, GlobalVar> =
+                name to GlobalVar(strNs, name, BridjeFunction(node.callTarget),
+                    type = FnType(params, ret).notNull())
+
+            return NsEnv(vars = mapOf(
+                gv("<-bytes".sym, StrFromBytesNode(language), listOf(bytes), str),
             ))
         }
     }

--- a/language/src/main/kotlin/brj/Reader.kt
+++ b/language/src/main/kotlin/brj/Reader.kt
@@ -15,7 +15,7 @@ class Reader private constructor(private val src: Source) {
     companion object {
         private val logger = System.getLogger("brj.Reader")
 
-        private val lang: Language = 
+        private val lang: Language =
             try {
                 NativeLibraryLoader.loadLibrary("tree-sitter-bridje", Arena.global())
                     .let { Language.load(it, "tree_sitter_bridje") }
@@ -35,10 +35,38 @@ class Reader private constructor(private val src: Source) {
         }
     }
 
+    // Tree-sitter reports UTF-8 byte offsets; Truffle Source.createSection expects
+    // character offsets. Precompute a byte->char map once per source so non-ASCII
+    // input doesn't feed bogus indices into createSection.
+    private val byteToChar: IntArray = run {
+        val chars = src.characters.toString()
+        val charLen = chars.length
+        val byteLen = chars.toByteArray(Charsets.UTF_8).size
+        val map = IntArray(byteLen + 1)
+        var byteIdx = 0
+        var charIdx = 0
+        while (charIdx < charLen) {
+            val cp = chars.codePointAt(charIdx)
+            val charCount = Character.charCount(cp)
+            val utf8Bytes = when {
+                cp < 0x80 -> 1
+                cp < 0x800 -> 2
+                cp < 0x10000 -> 3
+                else -> 4
+            }
+            repeat(utf8Bytes) { map[byteIdx + it] = charIdx }
+            byteIdx += utf8Bytes
+            charIdx += charCount
+        }
+        map[byteLen] = charLen
+        map
+    }
 
     fun Node.readForm(): Form {
         if (isError) throw RuntimeException("Error reading form: $text")
-        val loc = src.createSection(range.startByte, range.endByte - range.startByte)
+        val startChar = byteToChar[range.startByte]
+        val endChar = byteToChar[range.endByte]
+        val loc = src.createSection(startChar, endChar - startChar)
 
         return when (type) {
             "int" -> IntForm(text!!.toLong(), loc)

--- a/language/src/main/kotlin/brj/analyser/Analyser.kt
+++ b/language/src/main/kotlin/brj/analyser/Analyser.kt
@@ -1033,6 +1033,7 @@ data class Analyser(
             "Double" -> FloatType.notNull()
             "BigInt" -> BigIntType.notNull()
             "BigDec" -> BigDecType.notNull()
+            "Bytes" -> BytesType.notNull()
             "Nothing" -> nullType()
             else -> when {
                 name[0].isUpperCase() -> {

--- a/language/src/main/kotlin/brj/builtins/BytesBuiltins.kt
+++ b/language/src/main/kotlin/brj/builtins/BytesBuiltins.kt
@@ -1,0 +1,48 @@
+package brj.builtins
+
+import brj.BridjeLanguage
+import brj.runtime.Anomaly.Companion.incorrect
+import brj.runtime.BridjeContext
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary
+import com.oracle.truffle.api.frame.VirtualFrame
+import com.oracle.truffle.api.nodes.RootNode
+import com.oracle.truffle.api.strings.TruffleString
+
+class BytesCountNode(language: BridjeLanguage) : RootNode(language) {
+    override fun execute(frame: VirtualFrame): Any = doCount(frame.arguments[0])
+
+    @TruffleBoundary
+    private fun doCount(arg: Any): Long {
+        val arr = BridjeContext.get(this).truffleEnv.asHostObject(arg) as ByteArray
+        return arr.size.toLong()
+    }
+}
+
+class BytesNthNode(language: BridjeLanguage) : RootNode(language) {
+    override fun execute(frame: VirtualFrame): Any = doNth(frame.arguments[0], frame.arguments[1] as Long)
+
+    @TruffleBoundary
+    private fun doNth(arg: Any, index: Long): Long {
+        val arr = BridjeContext.get(this).truffleEnv.asHostObject(arg) as ByteArray
+        if (index < 0 || index >= arr.size) throw incorrect("Bytes/nth: index out of bounds: $index")
+        return (arr[index.toInt()].toInt() and 0xFF).toLong()
+    }
+}
+
+class BytesFromStrNode(language: BridjeLanguage) : RootNode(language) {
+    override fun execute(frame: VirtualFrame): Any = doConvert(frame.arguments[0] as TruffleString)
+
+    @TruffleBoundary
+    private fun doConvert(s: TruffleString): Any =
+        BridjeContext.get(this).truffleEnv.asGuestValue(s.toJavaStringUncached().toByteArray(Charsets.UTF_8))
+}
+
+class StrFromBytesNode(language: BridjeLanguage) : RootNode(language) {
+    override fun execute(frame: VirtualFrame): Any = doConvert(frame.arguments[0])
+
+    @TruffleBoundary
+    private fun doConvert(arg: Any): TruffleString {
+        val arr = BridjeContext.get(this).truffleEnv.asHostObject(arg) as ByteArray
+        return TruffleString.fromJavaStringUncached(String(arr, Charsets.UTF_8), TruffleString.Encoding.UTF_8)
+    }
+}

--- a/language/src/main/kotlin/brj/builtins/FsBuiltins.kt
+++ b/language/src/main/kotlin/brj/builtins/FsBuiltins.kt
@@ -51,6 +51,14 @@ class FsReadStringNode(language: BridjeLanguage) : RootNode(language) {
     }
 }
 
+class FsReadBytesNode(language: BridjeLanguage) : RootNode(language) {
+    override fun execute(frame: VirtualFrame): Any = doReadBytes(frame.arguments[0] as BridjeFile)
+
+    @TruffleBoundary
+    private fun doReadBytes(f: BridjeFile): Any =
+        BridjeContext.get(this).truffleEnv.asGuestValue(f.truffleFile.newInputStream().use { it.readAllBytes() })
+}
+
 class FsListNode(language: BridjeLanguage) : RootNode(language) {
     override fun execute(frame: VirtualFrame): Any = doList(frame.arguments[0] as BridjeFile)
 

--- a/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
+++ b/language/src/main/kotlin/brj/nodes/ParseRootNode.kt
@@ -372,6 +372,24 @@ class ParseRootNode(
                     source = source
                 )
             }
+            // brj:bytes starts with Bytes interop builtins
+            nsDecl?.name == "brj.bytes" -> NsEnv.withBytesBuiltins(lang).let { base ->
+                base.copy(
+                    requires = resolveRequires(frame),
+                    imports = nsDecl.imports,
+                    nsDecl = nsDecl,
+                    source = source
+                )
+            }
+            // brj:str starts with Str interop builtins
+            nsDecl?.name == "brj.str" -> NsEnv.withStrBuiltins(lang).let { base ->
+                base.copy(
+                    requires = resolveRequires(frame),
+                    imports = nsDecl.imports,
+                    nsDecl = nsDecl,
+                    source = source
+                )
+            }
             nsDecl != null -> nsDecl.resolve(frame)
             else -> NsEnv()
         }

--- a/language/src/main/kotlin/brj/types/Type.kt
+++ b/language/src/main/kotlin/brj/types/Type.kt
@@ -159,6 +159,21 @@ data class IteratorType(val el: Type): BaseType {
     override fun toString() = "Iterator(${el})"
 }
 
+// Virtual type — no dedicated runtime class.
+// At runtime a Bytes value is a Truffle HostObject wrapping a Java `byte[]`
+// (produced via `env.asGuestValue(byte[])`).
+// Builtins that consume Bytes unwrap via `env.asHostObject` back to `byte[]`;
+// this fast path is valid because v1 only produces Bytes through our own
+// builtins (`by/<-str`, `fs/<-bytes`).
+// Reads through Bytes/nth return the unsigned byte value widened to Int
+// (0..255); there is no Byte scalar type in Bridje.
+@ExportLibrary(InteropLibrary::class)
+data object BytesType: BaseType {
+    @Suppress("UNUSED_PARAMETER")
+    @ExportMessage fun toDisplayString(allowSideEffects: Boolean) = toString()
+    override fun toString() = "Bytes"
+}
+
 @ExportLibrary(InteropLibrary::class)
 data class FnType(val paramTypes: List<Type>, val returnType: Type): BaseType {
     @Suppress("UNUSED_PARAMETER")

--- a/language/src/test/kotlin/brj/BytesTest.kt
+++ b/language/src/test/kotlin/brj/BytesTest.kt
@@ -1,0 +1,121 @@
+package brj
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class BytesTest {
+
+    private fun Path.brjLit(): String = toString().replace("\\", "\\\\")
+
+    @Test
+    fun `Bytes count returns the byte length`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            ns: test.bytes.count
+              require:
+                brj:
+                  as(bytes, by)
+            def: result by/count(by/<-str("hello"))
+        """.trimIndent()).getMember("result")
+        assertEquals(5L, result.asLong())
+    }
+
+    @Test
+    fun `Bytes nth widens to Int`() = withContext { ctx ->
+        // "ABC" -> bytes [65, 66, 67]
+        val ns = ctx.evalBridje("""
+            ns: test.bytes.nth
+              require:
+                brj:
+                  as(bytes, by)
+            def: bs by/<-str("ABC")
+            def: b0 by/nth(bs, 0)
+            def: b1 by/nth(bs, 1)
+            def: b2 by/nth(bs, 2)
+        """.trimIndent())
+        assertEquals(65L, ns.getMember("b0").asLong())
+        assertEquals(66L, ns.getMember("b1").asLong())
+        assertEquals(67L, ns.getMember("b2").asLong())
+    }
+
+    @Test
+    fun `Bytes nth returns unsigned byte values`() = withContext { ctx ->
+        // "é" in UTF-8 is [0xC3, 0xA9] = [195, 169].
+        // Sign-extension would return -61 and -87 respectively; unsigned returns 195 and 169.
+        val ns = ctx.evalBridje("""
+            ns: test.bytes.nth.unsigned
+              require:
+                brj:
+                  as(bytes, by)
+            def: bs by/<-str("é")
+            def: b0 by/nth(bs, 0)
+            def: b1 by/nth(bs, 1)
+        """.trimIndent())
+        assertEquals(195L, ns.getMember("b0").asLong())
+        assertEquals(169L, ns.getMember("b1").asLong())
+    }
+
+    @Test
+    fun `Str Bytes roundtrip preserves ASCII`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            ns: test.bytes.roundtrip.ascii
+              require:
+                brj:
+                  as(bytes, by)
+                  as(str, s)
+            def: result s/<-bytes(by/<-str("hello, world"))
+        """.trimIndent()).getMember("result")
+        assertEquals("hello, world", result.asString())
+    }
+
+    @Test
+    fun `Str Bytes roundtrip preserves multibyte UTF-8`() = withContext { ctx ->
+        val result = ctx.evalBridje("""
+            ns: test.bytes.roundtrip.utf8
+              require:
+                brj:
+                  as(bytes, by)
+                  as(str, s)
+            def: result s/<-bytes(by/<-str("héllo"))
+        """.trimIndent()).getMember("result")
+        assertEquals("héllo", result.asString())
+    }
+
+    @Test
+    fun `multibyte character takes multiple bytes`() = withContext { ctx ->
+        // "é" in UTF-8 is two bytes (0xC3 0xA9).
+        val result = ctx.evalBridje("""
+            ns: test.bytes.utf8len
+              require:
+                brj:
+                  as(bytes, by)
+            def: result by/count(by/<-str("é"))
+        """.trimIndent()).getMember("result")
+        assertEquals(2L, result.asLong())
+    }
+
+    @Test
+    fun `fs read-bytes returns file contents as Bytes`(@TempDir dir: Path) = withContext { ctx ->
+        val target = dir.resolve("payload.bin")
+        Files.write(target, byteArrayOf(0x48, 0x65, 0x6C, 0x6C, 0x6F)) // "Hello"
+
+        val ns = ctx.evalBridje("""
+            ns: test.bytes.fs.readbytes
+              require:
+                brj:
+                  fs
+                  as(bytes, by)
+                  as(str, s)
+            def: bs fs/<-bytes(fs/file("${target.brjLit()}"))
+            def: size by/count(bs)
+            def: first by/nth(bs, 0)
+            def: text s/<-bytes(bs)
+        """.trimIndent())
+
+        assertEquals(5L, ns.getMember("size").asLong())
+        assertEquals(0x48L, ns.getMember("first").asLong())
+        assertEquals("Hello", ns.getMember("text").asString())
+    }
+}


### PR DESCRIPTION
Adds `Bytes` as a virtual type in the type system, backed at runtime by a Truffle `HostObject` wrapping a Java `byte[]`.
Ships with enough surface to unblock `brj.fs` binary I/O — the stated motivation in #99.

Stacked on #110 (with() record update).

## Two commits

### `fix: Reader passes char offsets to Source.createSection`

Surfaced by the multibyte tests in this PR, but the bug predates it: tree-sitter reports UTF-8 byte offsets in `Node.range`, while Truffle's `Source.createSection` expects character offsets.
For ASCII source the two coincide, which is why no earlier test caught it.
Precomputes a byte → char offset map once per `Reader` instance and indexes into it when building the `SourceSection`.

### `feat: Bytes virtual type and brj.fs read-bytes`

- `BytesType` is a virtual type — no Bridje-owned wrapper class. `asGuestValue` lets us return a `byte[]` directly while still satisfying Truffle's interop post-condition contract; the consumer side calls `asHostObject` and casts back to `ByteArray`, safe because v1 only produces `Bytes` via our own builtins.
- Surface:
  - `brj.bytes/count   :: Bytes -> Int`
  - `brj.bytes/nth     :: Bytes -> Int -> Int` (widens signed byte to Int)
  - `brj.bytes/<-str   :: Str   -> Bytes` (UTF-8 encode)
  - `brj.str/<-bytes   :: Bytes -> Str` (UTF-8 decode)
  - `brj.fs/<-bytes    :: File  -> Bytes`

## Out of scope (future slices)

- Byte-level mutation.
- Multi-byte aligned reads / endianness (opting into the buffer protocol forces the full buffer method set via the Kotlin DSL — deliberately not paying that cost in v1).
- `ByteBuffer` support.
- Accepting non-HostObject array-of-byte shapes as `Bytes`.

A `Byte` scalar type is deliberately not introduced; reads widen to `Int`, matching the existing convention for character / codepoint reads.

## Display

`Bytes` values render as the default array-element display (e.g. `[104, 101, 108, 108, 111]`) rather than a `Bytes(N)` façade.
A `LanguageView` was explored and discarded — polyglot `Value.toString()` resolves a host-wrapped `byte[]` as a host-owned value, so Bridje's language view is never consulted for it.
A thin `BridjeBytes` wrapper would fix the display; deferred as a deliberate trade to stay close to the metal.

## Tests

6 tests in `BytesTest`, covering ASCII, multibyte UTF-8 round-trip, element widening, and file-read.
Full `:language:test` green.