### PR TITLE
rename brj.forms ns to brj.rdr

### DIFF
--- a/language/src/main/brj/brj/core.brj
+++ b/language/src/main/brj/brj/core.brj
@@ -2,7 +2,7 @@ ns: brj.core
   import:
     brj.runtime: as(BridjeVector, Vec)
   require:
-    brj: as(forms, f)
+    brj: as(rdr, f)
 
 decl: [a] Vec/count([a]) Int
 decl: [a] Vec/first([a]) a

--- a/language/src/main/kotlin/brj/Form.kt
+++ b/language/src/main/kotlin/brj/Form.kt
@@ -16,7 +16,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 
 // Meta objects for each form type
-object SymbolFormMeta : BuiltinMetaObj("SymbolForm".sym, "brj.forms".sym) {
+object SymbolFormMeta : BuiltinMetaObj("SymbolForm".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is SymbolForm
 
     @Throws(ArityException::class)
@@ -27,7 +27,7 @@ object SymbolFormMeta : BuiltinMetaObj("SymbolForm".sym, "brj.forms".sym) {
     }
 }
 
-object QSymbolFormMeta : BuiltinMetaObj("QSymbolForm".sym, "brj.forms".sym) {
+object QSymbolFormMeta : BuiltinMetaObj("QSymbolForm".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is QSymbolForm
 
     @Throws(ArityException::class)
@@ -39,7 +39,7 @@ object QSymbolFormMeta : BuiltinMetaObj("QSymbolForm".sym, "brj.forms".sym) {
     }
 }
 
-object ListMeta : BuiltinMetaObj("List".sym, "brj.forms".sym) {
+object ListMeta : BuiltinMetaObj("List".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is ListForm
 
     @Throws(ArityException::class)
@@ -50,7 +50,7 @@ object ListMeta : BuiltinMetaObj("List".sym, "brj.forms".sym) {
     }
 }
 
-object VectorMeta : BuiltinMetaObj("Vector".sym, "brj.forms".sym) {
+object VectorMeta : BuiltinMetaObj("Vector".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is VectorForm
 
     @Throws(ArityException::class)
@@ -61,7 +61,7 @@ object VectorMeta : BuiltinMetaObj("Vector".sym, "brj.forms".sym) {
     }
 }
 
-object RecordMeta : BuiltinMetaObj("Record".sym, "brj.forms".sym) {
+object RecordMeta : BuiltinMetaObj("Record".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is RecordForm
 
     @Throws(ArityException::class)
@@ -72,7 +72,7 @@ object RecordMeta : BuiltinMetaObj("Record".sym, "brj.forms".sym) {
     }
 }
 
-object SetMeta : BuiltinMetaObj("Set".sym, "brj.forms".sym) {
+object SetMeta : BuiltinMetaObj("Set".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is SetForm
 
     @Throws(ArityException::class)
@@ -83,7 +83,7 @@ object SetMeta : BuiltinMetaObj("Set".sym, "brj.forms".sym) {
     }
 }
 
-object IntMeta : BuiltinMetaObj("Int".sym, "brj.forms".sym) {
+object IntMeta : BuiltinMetaObj("Int".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is IntForm
 
     @Throws(ArityException::class)
@@ -93,7 +93,7 @@ object IntMeta : BuiltinMetaObj("Int".sym, "brj.forms".sym) {
     }
 }
 
-object DoubleMeta : BuiltinMetaObj("Double".sym, "brj.forms".sym) {
+object DoubleMeta : BuiltinMetaObj("Double".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is DoubleForm
 
     @Throws(ArityException::class)
@@ -103,7 +103,7 @@ object DoubleMeta : BuiltinMetaObj("Double".sym, "brj.forms".sym) {
     }
 }
 
-object StringMeta : BuiltinMetaObj("String".sym, "brj.forms".sym) {
+object StringMeta : BuiltinMetaObj("String".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is StringForm
 
     @Throws(ArityException::class)
@@ -114,7 +114,7 @@ object StringMeta : BuiltinMetaObj("String".sym, "brj.forms".sym) {
     }
 }
 
-object BigIntMeta : BuiltinMetaObj("BigInt".sym, "brj.forms".sym) {
+object BigIntMeta : BuiltinMetaObj("BigInt".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is BigIntForm
 
     @Throws(ArityException::class)
@@ -124,7 +124,7 @@ object BigIntMeta : BuiltinMetaObj("BigInt".sym, "brj.forms".sym) {
     }
 }
 
-object BigDecMeta : BuiltinMetaObj("BigDec".sym, "brj.forms".sym) {
+object BigDecMeta : BuiltinMetaObj("BigDec".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is BigDecForm
 
     @Throws(ArityException::class)
@@ -134,7 +134,7 @@ object BigDecMeta : BuiltinMetaObj("BigDec".sym, "brj.forms".sym) {
     }
 }
 
-object KeywordFormMeta : BuiltinMetaObj("KeywordForm".sym, "brj.forms".sym) {
+object KeywordFormMeta : BuiltinMetaObj("KeywordForm".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is KeywordForm
 
     @Throws(ArityException::class)
@@ -145,7 +145,7 @@ object KeywordFormMeta : BuiltinMetaObj("KeywordForm".sym, "brj.forms".sym) {
     }
 }
 
-object QKeywordFormMeta : BuiltinMetaObj("QKeywordForm".sym, "brj.forms".sym) {
+object QKeywordFormMeta : BuiltinMetaObj("QKeywordForm".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is QKeywordForm
 
     @Throws(ArityException::class)
@@ -157,7 +157,7 @@ object QKeywordFormMeta : BuiltinMetaObj("QKeywordForm".sym, "brj.forms".sym) {
     }
 }
 
-object DotSymbolFormMeta : BuiltinMetaObj("DotSymbolForm".sym, "brj.forms".sym) {
+object DotSymbolFormMeta : BuiltinMetaObj("DotSymbolForm".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is DotSymbolForm
 
     @Throws(ArityException::class)
@@ -168,7 +168,7 @@ object DotSymbolFormMeta : BuiltinMetaObj("DotSymbolForm".sym, "brj.forms".sym) 
     }
 }
 
-object QDotSymbolFormMeta : BuiltinMetaObj("QDotSymbolForm".sym, "brj.forms".sym) {
+object QDotSymbolFormMeta : BuiltinMetaObj("QDotSymbolForm".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is QDotSymbolForm
 
     @Throws(ArityException::class)
@@ -180,7 +180,7 @@ object QDotSymbolFormMeta : BuiltinMetaObj("QDotSymbolForm".sym, "brj.forms".sym
     }
 }
 
-object UnquoteMeta : BuiltinMetaObj("Unquote".sym, "brj.forms".sym) {
+object UnquoteMeta : BuiltinMetaObj("Unquote".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is UnquoteForm
 
     @Throws(ArityException::class)
@@ -190,7 +190,7 @@ object UnquoteMeta : BuiltinMetaObj("Unquote".sym, "brj.forms".sym) {
     }
 }
 
-object UnquoteSpliceMeta : BuiltinMetaObj("UnquoteSplice".sym, "brj.forms".sym) {
+object UnquoteSpliceMeta : BuiltinMetaObj("UnquoteSplice".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is UnquoteSpliceForm
 
     @Throws(ArityException::class)
@@ -200,7 +200,7 @@ object UnquoteSpliceMeta : BuiltinMetaObj("UnquoteSplice".sym, "brj.forms".sym) 
     }
 }
 
-object SyntaxQuoteMeta : BuiltinMetaObj("SyntaxQuote".sym, "brj.forms".sym) {
+object SyntaxQuoteMeta : BuiltinMetaObj("SyntaxQuote".sym, "brj.rdr".sym) {
     override fun isMetaInstance(instance: Any?) = instance is SyntaxQuoteForm
 
     @Throws(ArityException::class)

--- a/language/src/main/kotlin/brj/NsEnv.kt
+++ b/language/src/main/kotlin/brj/NsEnv.kt
@@ -77,37 +77,37 @@ data class NsEnv(
             return NsEnv(vars = builtinDataMetas + builtinFunctions + anomalyTags)
         }
 
-        fun withFormsBuiltins(language: BridjeLanguage): NsEnv {
-            val formsNs = "brj.forms".sym
+        fun withReaderBuiltins(language: BridjeLanguage): NsEnv {
+            val readerNs = "brj.rdr".sym
             val formVec = VectorType(FormType.notNull()).notNull()
             val fileType = TagType("brj.fs", "File").notNull()
             val str = StringType.notNull()
 
             fun readerFn(name: String, node: RootNode, paramType: Type): Pair<Symbol, GlobalVar> {
                 val sym = name.sym
-                return sym to GlobalVar(formsNs, sym, BridjeFunction(node.callTarget),
+                return sym to GlobalVar(readerNs, sym, BridjeFunction(node.callTarget),
                     type = FnType(listOf(paramType), formVec).notNull())
             }
 
             return NsEnv(vars = mapOf(
-                "SymbolForm".sym to GlobalVar(formsNs, "SymbolForm".sym, SymbolFormMeta),
-                "QSymbolForm".sym to GlobalVar(formsNs, "QSymbolForm".sym, QSymbolFormMeta),
-                "KeywordForm".sym to GlobalVar(formsNs, "KeywordForm".sym, KeywordFormMeta),
-                "QKeywordForm".sym to GlobalVar(formsNs, "QKeywordForm".sym, QKeywordFormMeta),
-                "DotSymbolForm".sym to GlobalVar(formsNs, "DotSymbolForm".sym, DotSymbolFormMeta),
-                "QDotSymbolForm".sym to GlobalVar(formsNs, "QDotSymbolForm".sym, QDotSymbolFormMeta),
-                "List".sym to GlobalVar(formsNs, "List".sym, ListMeta),
-                "Vector".sym to GlobalVar(formsNs, "Vector".sym, VectorMeta),
-                "Record".sym to GlobalVar(formsNs, "Record".sym, RecordMeta),
-                "Set".sym to GlobalVar(formsNs, "Set".sym, SetMeta),
-                "Int".sym to GlobalVar(formsNs, "Int".sym, IntMeta),
-                "Double".sym to GlobalVar(formsNs, "Double".sym, DoubleMeta),
-                "String".sym to GlobalVar(formsNs, "String".sym, StringMeta),
-                "BigInt".sym to GlobalVar(formsNs, "BigInt".sym, BigIntMeta),
-                "BigDec".sym to GlobalVar(formsNs, "BigDec".sym, BigDecMeta),
-                "Unquote".sym to GlobalVar(formsNs, "Unquote".sym, UnquoteMeta),
-                "UnquoteSplice".sym to GlobalVar(formsNs, "UnquoteSplice".sym, UnquoteSpliceMeta),
-                "SyntaxQuote".sym to GlobalVar(formsNs, "SyntaxQuote".sym, SyntaxQuoteMeta),
+                "SymbolForm".sym to GlobalVar(readerNs, "SymbolForm".sym, SymbolFormMeta),
+                "QSymbolForm".sym to GlobalVar(readerNs, "QSymbolForm".sym, QSymbolFormMeta),
+                "KeywordForm".sym to GlobalVar(readerNs, "KeywordForm".sym, KeywordFormMeta),
+                "QKeywordForm".sym to GlobalVar(readerNs, "QKeywordForm".sym, QKeywordFormMeta),
+                "DotSymbolForm".sym to GlobalVar(readerNs, "DotSymbolForm".sym, DotSymbolFormMeta),
+                "QDotSymbolForm".sym to GlobalVar(readerNs, "QDotSymbolForm".sym, QDotSymbolFormMeta),
+                "List".sym to GlobalVar(readerNs, "List".sym, ListMeta),
+                "Vector".sym to GlobalVar(readerNs, "Vector".sym, VectorMeta),
+                "Record".sym to GlobalVar(readerNs, "Record".sym, RecordMeta),
+                "Set".sym to GlobalVar(readerNs, "Set".sym, SetMeta),
+                "Int".sym to GlobalVar(readerNs, "Int".sym, IntMeta),
+                "Double".sym to GlobalVar(readerNs, "Double".sym, DoubleMeta),
+                "String".sym to GlobalVar(readerNs, "String".sym, StringMeta),
+                "BigInt".sym to GlobalVar(readerNs, "BigInt".sym, BigIntMeta),
+                "BigDec".sym to GlobalVar(readerNs, "BigDec".sym, BigDecMeta),
+                "Unquote".sym to GlobalVar(readerNs, "Unquote".sym, UnquoteMeta),
+                "UnquoteSplice".sym to GlobalVar(readerNs, "UnquoteSplice".sym, UnquoteSpliceMeta),
+                "SyntaxQuote".sym to GlobalVar(readerNs, "SyntaxQuote".sym, SyntaxQuoteMeta),
                 readerFn("<-file", FormsFromFileNode(language), fileType),
                 readerFn("<-str", FormsFromStringNode(language), str),
             ))

--- a/language/src/main/kotlin/brj/analyser/Analyser.kt
+++ b/language/src/main/kotlin/brj/analyser/Analyser.kt
@@ -283,7 +283,7 @@ data class Analyser(
     private fun callFormConstructor(name: String, args: List<ValueExpr>, loc: SourceSection?): ValueExpr {
         val sym = Symbol.intern(name)
         // Quoting machinery: form constructors and Symbol/Var must be reachable regardless of the user's ns/requires.
-        val constructor = ctx.namespaces["brj.forms"]?.get(sym) ?: ctx.brjCore[sym]
+        val constructor = ctx.namespaces["brj.rdr"]?.get(sym) ?: ctx.brjCore[sym]
             ?: return errorExpr("$name constructor not found", loc)
         return CallExpr(GlobalVarExpr(constructor, loc), args, loc)
     }

--- a/language/src/main/kotlin/brj/runtime/BridjeContext.kt
+++ b/language/src/main/kotlin/brj/runtime/BridjeContext.kt
@@ -22,7 +22,7 @@ class BridjeContext(val truffleEnv: Env, val lang: BridjeLanguage) {
 
     var globalEnv: GlobalEnv = GlobalEnv(namespaces = mapOf(
         "brj.core" to brjCore,
-        "brj.forms" to NsEnv.withFormsBuiltins(lang),
+        "brj.rdr" to NsEnv.withReaderBuiltins(lang),
     ))
         private set
 

--- a/language/src/test/kotlin/brj/EvalTest.kt
+++ b/language/src/test/kotlin/brj/EvalTest.kt
@@ -22,10 +22,10 @@ internal fun Context.evalBridje(src: String) = eval("bridje", src)
 private const val FORMS_NS_HEADER =
     "ns: test.forms\n" +
     "  require:\n" +
-    "    brj: as(forms, f)\n"
+    "    brj: as(rdr, f)\n"
 
 /**
- * Runs `expr` inside an anonymous ns that requires `brj.forms :as f`.
+ * Runs `expr` inside an anonymous ns that requires `brj.rdr :as f`.
  * Wraps `expr` in `def: __result` so the returned [Value] is the expression's value,
  * not the ns itself.
  */

--- a/language/src/test/kotlin/brj/FormsReadersTest.kt
+++ b/language/src/test/kotlin/brj/FormsReadersTest.kt
@@ -15,7 +15,7 @@ class FormsReadersTest {
         val result = ctx.evalBridje("""
             ns: test.forms.str1
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             def: result f/<-str("foo")
         """.trimIndent()).getMember("result")
@@ -31,7 +31,7 @@ class FormsReadersTest {
         val result = ctx.evalBridje("""
             ns: test.forms.str2
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             def: result f/<-str("1 2 3")
         """.trimIndent()).getMember("result")
@@ -47,7 +47,7 @@ class FormsReadersTest {
         val result = ctx.evalBridje("""
             ns: test.forms.str3
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             def: result f/<-str("(foo 1 2)")
         """.trimIndent()).getMember("result")
@@ -67,7 +67,7 @@ class FormsReadersTest {
             ns: test.forms.file
               require:
                 brj:
-                  as(forms, f)
+                  as(rdr, f)
                   fs
 
             def: result f/<-file(fs/file("${target.brjLit()}"))
@@ -85,7 +85,7 @@ class FormsReadersTest {
         val result = ctx.evalBridje("""
             ns: test.forms.empty
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             def: result f/<-str("")
         """.trimIndent()).getMember("result")

--- a/language/src/test/kotlin/brj/MacroTest.kt
+++ b/language/src/test/kotlin/brj/MacroTest.kt
@@ -11,7 +11,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             ns: test.macros
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             defmacro: unless(cond, body)
               f/List([f/SymbolForm(Symbol("if")) cond 'nil body])
@@ -26,7 +26,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             ns: test.macros
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             defmacro: when(cond, body)
               f/List([f/SymbolForm(Symbol("if")) cond body 'nil])
@@ -41,7 +41,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             ns: test.macros
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             defmacro: when(cond, body)
               f/List([f/SymbolForm(Symbol("if")) cond body 'nil])
@@ -56,7 +56,7 @@ class MacroTest {
         val result1 = ctx.evalBridje("""
             ns: test.macros
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             defmacro: if-not(cond, then, else)
               f/List([f/SymbolForm(Symbol("if")) cond else then])
@@ -357,7 +357,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             ns: test.macros
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             defmacro: countRest(& rest)
               f/Int(count(rest))
@@ -372,7 +372,7 @@ class MacroTest {
         val result = ctx.evalBridje("""
             ns: test.macros
               require:
-                brj: as(forms, f)
+                brj: as(rdr, f)
 
             defmacro: countRest(& rest)
               f/Int(count(rest))


### PR DESCRIPTION
Shortens the reader-entry namespace from `brj.forms` to `brj.rdr` so users can require it without an alias.

Before:
```
require: brj: as(forms, f)
... f/<-file ...
```

After:
```
require: brj: rdr
... rdr/<-file ...
```

Pure rename: Kotlin helper becomes `withReaderBuiltins`, all namespace registrations and test imports follow suit.
No behavioural change, no deprecation shim.

Independent of the #109 → #110 → #111 stack; targets `main` directly.

## Tests

Full `:language:test` green — 580/580.